### PR TITLE
Make attr.Classes a map type

### DIFF
--- a/attr/attributes.go
+++ b/attr/attributes.go
@@ -19,15 +19,23 @@ func Class(v string) g.Node {
 	return g.Attr("class", v)
 }
 
-// Classes returns an attribute with name "class" and the value being a sorted, space-separated string of all the keys,
-// for which the corresponding value is true.
-func Classes(cs map[string]bool) g.Node {
+// Classes is a map of strings to booleans, which Renders to an attribute with name "class".
+// The attribute value is a sorted, space-separated string of all the map keys,
+// for which the corresponding map value is true.
+type Classes map[string]bool
+
+func (c Classes) Render() string {
 	var included []string
-	for c, include := range cs {
+	for c, include := range c {
 		if include {
 			included = append(included, c)
 		}
 	}
 	sort.Strings(included)
-	return g.Attr("class", strings.Join(included, " "))
+	return g.Attr("class", strings.Join(included, " ")).Render()
+}
+
+// String satisfies fmt.Stringer.
+func (c Classes) String() string {
+	return c.Render()
 }

--- a/attr/attributes_test.go
+++ b/attr/attributes_test.go
@@ -21,11 +21,18 @@ func TestClass(t *testing.T) {
 
 func TestClasses(t *testing.T) {
 	t.Run("given a map, returns sorted keys from the map with value true", func(t *testing.T) {
-		assert.Equal(t, ` class="boheme-hat hat partyhat"`, attr.Classes(map[string]bool{
+		assert.Equal(t, ` class="boheme-hat hat partyhat"`, attr.Classes{
 			"boheme-hat": true,
 			"hat":        true,
 			"partyhat":   true,
 			"turtlehat":  false,
-		}))
+		})
+	})
+
+	t.Run("also works with fmt", func(t *testing.T) {
+		a := attr.Classes{"hat": true}
+		if a.String() != ` class="hat"` {
+			t.FailNow()
+		}
 	})
 }


### PR DESCRIPTION
This makes the usage syntax prettier. Instead of `attr.Classes(map[string]bool{})`, we can just use `attr.Classes{}`.