### PR TITLE
Introduce Placer interface

### DIFF
--- a/attr/attributes.go
+++ b/attr/attributes.go
@@ -35,6 +35,10 @@ func (c Classes) Render() string {
 	return g.Attr("class", strings.Join(included, " ")).Render()
 }
 
+func (c Classes) Place() g.Placement {
+	return g.Inside
+}
+
 // String satisfies fmt.Stringer.
 func (c Classes) String() string {
 	return c.Render()

--- a/attr/attributes_test.go
+++ b/attr/attributes_test.go
@@ -3,6 +3,7 @@ package attr_test
 import (
 	"testing"
 
+	g "github.com/maragudk/gomponents"
 	"github.com/maragudk/gomponents/assert"
 	"github.com/maragudk/gomponents/attr"
 )
@@ -27,6 +28,11 @@ func TestClasses(t *testing.T) {
 			"partyhat":   true,
 			"turtlehat":  false,
 		})
+	})
+
+	t.Run("renders as attribute in an element", func(t *testing.T) {
+		e := g.El("div", attr.Classes{"hat": true})
+		assert.Equal(t, `<div class="hat"/>`, e)
 	})
 
 	t.Run("also works with fmt", func(t *testing.T) {

--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -52,6 +52,12 @@ func TestAttr(t *testing.T) {
 	})
 }
 
+type outsider struct{}
+
+func (o outsider) Render() string {
+	return "outsider"
+}
+
 func TestEl(t *testing.T) {
 	t.Run("renders an empty element if no children given", func(t *testing.T) {
 		e := g.El("div")
@@ -71,6 +77,11 @@ func TestEl(t *testing.T) {
 	t.Run("renders attributes at the correct place regardless of placement in parameter list", func(t *testing.T) {
 		e := g.El("div", g.El("span"), g.Attr("class", "hat"))
 		assert.Equal(t, `<div class="hat"><span/></div>`, e)
+	})
+
+	t.Run("renders outside if node does not implement placer", func(t *testing.T) {
+		e := g.El("div", outsider{})
+		assert.Equal(t, `<div>outsider</div>`, e)
 	})
 }
 


### PR DESCRIPTION
When implemented, the `Place` method of the `Placer` interface tells `Render` in `El` where to put a Node. This is relevant for helpers that want to be rendered like attributes, inside the parent element.

Fixes the bug where `attr.Classes` was rendered outside the element.