### PR TITLE
Don't render or error on nil children

### DIFF
--- a/gomponents.go
+++ b/gomponents.go
@@ -84,6 +84,9 @@ func El(name string, children ...Node) NodeFunc {
 }
 
 func renderChild(c Node, inside, outside *strings.Builder) {
+	if c == nil {
+		return
+	}
 	if g, ok := c.(group); ok {
 		for _, groupC := range g.children {
 			renderChild(groupC, inside, outside)

--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -83,6 +83,11 @@ func TestEl(t *testing.T) {
 		e := g.El("div", outsider{})
 		assert.Equal(t, `<div>outsider</div>`, e)
 	})
+
+	t.Run("does not fail on nil node", func(t *testing.T) {
+		e := g.El("div", g.El("span"), nil, g.El("span"))
+		assert.Equal(t, `<div><span /><span /></div>`, e)
+	})
 }
 
 func TestText(t *testing.T) {


### PR DESCRIPTION
This makes it easier to e.g. conditionally skip a component for rendering.