### PR TITLE
Remove fmt.Sprintf call in attribute Render

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: cover lint test
+.PHONY: benchmark cover lint test
+
+benchmark:
+	go test -bench=.
 
 cover:
 	go tool cover -html=cover.out

--- a/gomponents.go
+++ b/gomponents.go
@@ -129,9 +129,9 @@ type attr struct {
 
 func (a *attr) Render() string {
 	if a.value == nil {
-		return fmt.Sprintf(" %v", a.name)
+		return " " + a.name
 	}
-	return fmt.Sprintf(` %v="%v"`, a.name, *a.value)
+	return " " + a.name + `="` + *a.value + `"`
 }
 
 func (a *attr) Place() Placement {

--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -52,6 +52,22 @@ func TestAttr(t *testing.T) {
 	})
 }
 
+func BenchmarkAttr(b *testing.B) {
+	b.Run("boolean attributes", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			a := g.Attr("hat")
+			a.Render()
+		}
+	})
+
+	b.Run("name-value attributes", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			a := g.Attr("hat", "party")
+			a.Render()
+		}
+	})
+}
+
 type outsider struct{}
 
 func (o outsider) Render() string {


### PR DESCRIPTION
Just concatenating the strings is much faster.

Before:

```
make benchmark
go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/maragudk/gomponents
BenchmarkAttr/boolean_attributes-8         	 8194791	       139 ns/op
BenchmarkAttr/name-value_attributes-8      	 5143292	       229 ns/op
PASS
ok  	github.com/maragudk/gomponents	2.841s
```

After:

```
make benchmark
go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/maragudk/gomponents
BenchmarkAttr/boolean_attributes-8         	16755404	        67.0 ns/op
BenchmarkAttr/name-value_attributes-8      	10208625	       116 ns/op
PASS
ok  	github.com/maragudk/gomponents	2.702s
```