### PR TITLE
Render to Writer instead of string

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ func main() {
 func handler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		page := Page("Hi!", r.URL.Path)
-		_ = g.Write(w, page)
+		_ = page.Render(w)
 	}
 }
 
@@ -91,7 +91,7 @@ func main() {
 func handler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		page := Page("Hi!", r.URL.Path)
-		_ = g.Write(w, page)
+		_ = page.Render(w)
 	}
 }
 

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -16,3 +16,10 @@ func Equal(t *testing.T, expected string, actual g.Node) {
 		t.FailNow()
 	}
 }
+
+// Error checks for a non-nil error.
+func Error(t *testing.T, err error) {
+	if err == nil {
+		t.FailNow()
+	}
+}

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -1,6 +1,7 @@
 package assert
 
 import (
+	"strings"
 	"testing"
 
 	g "github.com/maragudk/gomponents"
@@ -8,7 +9,9 @@ import (
 
 // Equal checks for equality between the given expected string and the rendered Node string.
 func Equal(t *testing.T, expected string, actual g.Node) {
-	if expected != actual.Render() {
+	var b strings.Builder
+	_ = actual.Render(&b)
+	if expected != b.String() {
 		t.Errorf("expected `%v` but got `%v`", expected, actual)
 		t.FailNow()
 	}

--- a/attr/attributes.go
+++ b/attr/attributes.go
@@ -3,6 +3,7 @@
 package attr
 
 import (
+	"io"
 	"sort"
 	"strings"
 
@@ -14,7 +15,7 @@ import (
 // for which the corresponding map value is true.
 type Classes map[string]bool
 
-func (c Classes) Render() string {
+func (c Classes) Render(w io.Writer) error {
 	var included []string
 	for c, include := range c {
 		if include {
@@ -22,7 +23,7 @@ func (c Classes) Render() string {
 		}
 	}
 	sort.Strings(included)
-	return g.Attr("class", strings.Join(included, " ")).Render()
+	return g.Attr("class", strings.Join(included, " ")).Render(w)
 }
 
 func (c Classes) Place() g.Placement {
@@ -31,5 +32,7 @@ func (c Classes) Place() g.Placement {
 
 // String satisfies fmt.Stringer.
 func (c Classes) String() string {
-	return c.Render()
+	var b strings.Builder
+	_ = c.Render(&b)
+	return b.String()
 }

--- a/el/elements.go
+++ b/el/elements.go
@@ -4,7 +4,7 @@ package el
 
 import (
 	"fmt"
-	"strings"
+	"io"
 
 	g "github.com/maragudk/gomponents"
 )
@@ -13,15 +13,13 @@ func A(href string, children ...g.Node) g.NodeFunc {
 	return g.El("a", g.Attr("href", href), g.Group(children))
 }
 
-// Document returns an special kind of Node that prefixes its children with the string "<!doctype html>".
-func Document(children ...g.Node) g.NodeFunc {
-	return func() string {
-		var b strings.Builder
-		b.WriteString("<!doctype html>")
-		for _, c := range children {
-			b.WriteString(c.Render())
+// Document returns an special kind of Node that prefixes its child with the string "<!doctype html>".
+func Document(child g.Node) g.NodeFunc {
+	return func(w io.Writer) error {
+		if _, err := w.Write([]byte("<!doctype html>")); err != nil {
+			return err
 		}
-		return b.String()
+		return child.Render(w)
 	}
 }
 

--- a/el/elements_test.go
+++ b/el/elements_test.go
@@ -1,6 +1,7 @@
 package el_test
 
 import (
+	"errors"
 	"testing"
 
 	g "github.com/maragudk/gomponents"
@@ -8,9 +9,20 @@ import (
 	"github.com/maragudk/gomponents/el"
 )
 
+type erroringWriter struct{}
+
+func (w *erroringWriter) Write(p []byte) (n int, err error) {
+	return 0, errors.New("don't want to write")
+}
+
 func TestDocument(t *testing.T) {
 	t.Run("returns doctype and children", func(t *testing.T) {
 		assert.Equal(t, `<!doctype html><html />`, el.Document(g.El("html")))
+	})
+
+	t.Run("errors on write error in Render", func(t *testing.T) {
+		err := el.Document(g.El("html")).Render(&erroringWriter{})
+		assert.Error(t, err)
 	})
 }
 

--- a/examples/simple/simple.go
+++ b/examples/simple/simple.go
@@ -14,22 +14,23 @@ func main() {
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	_ = g.Write(w, page(pageProps{
+	p := page(props{
 		title: r.URL.Path,
 		path:  r.URL.Path,
-	}))
+	})
+	_ = p.Render(w)
 }
 
-type pageProps struct {
+type props struct {
 	title string
 	path  string
 }
 
-func page(props pageProps) g.Node {
+func page(p props) g.Node {
 	return el.Document(
 		el.HTML(attr.Lang("en"),
 			el.Head(
-				el.Title(props.title),
+				el.Title(p.title),
 				el.Style(attr.Type("text/css"),
 					g.Raw(".is-active{font-weight: bold}"),
 					g.Raw("ul.nav { list-style-type: none; margin: 0; padding: 0; overflow: hidden; }"),
@@ -37,10 +38,10 @@ func page(props pageProps) g.Node {
 				),
 			),
 			el.Body(
-				navbar(navbarProps{path: props.path}),
+				navbar(navbarProps{path: p.path}),
 				el.Hr(),
-				el.H1(props.title),
-				el.P(g.Textf("Welcome to the page at %v.", props.path)),
+				el.H1(p.title),
+				el.P(g.Textf("Welcome to the page at %v.", p.path)),
 				el.P(g.Textf("Rendered at %v", time.Now())),
 			),
 		),

--- a/gomponents.go
+++ b/gomponents.go
@@ -17,6 +17,7 @@ import (
 // Node is a DOM node that can Render itself to a io.Writer.
 type Node interface {
 	Render(w io.Writer) error
+	fmt.Stringer
 }
 
 // Placer can be implemented to tell Render functions where to place the string representation of a Node
@@ -214,6 +215,10 @@ func Raw(t string) NodeFunc {
 
 type group struct {
 	children []Node
+}
+
+func (g group) String() string {
+	panic("cannot render group directly")
 }
 
 func (g group) Render(io.Writer) error {

--- a/gomponents.go
+++ b/gomponents.go
@@ -17,7 +17,6 @@ import (
 // Node is a DOM node that can Render itself to a io.Writer.
 type Node interface {
 	Render(w io.Writer) error
-	fmt.Stringer
 }
 
 // Placer can be implemented to tell Render functions where to place the string representation of a Node
@@ -94,7 +93,7 @@ func El(name string, children ...Node) NodeFunc {
 }
 
 // renderChild c to the given writer w if the node type is t.
-// Returns whether the child would be written Outside.
+// Returns whether the child would be written Outside, regardless of whether it is actually written.
 func renderChild(w *statefulWriter, c Node, t nodeType) bool {
 	if w.err != nil || c == nil {
 		return false

--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -73,6 +73,10 @@ func BenchmarkAttr(b *testing.B) {
 
 type outsider struct{}
 
+func (o outsider) String() string {
+	return "outsider"
+}
+
 func (o outsider) Render(w io.Writer) error {
 	_, _ = w.Write([]byte("outsider"))
 	return nil

--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -157,28 +157,28 @@ func TestGroup(t *testing.T) {
 
 	t.Run("panics on direct render", func(t *testing.T) {
 		e := g.Group(nil)
-		panicced := false
+		panicked := false
 		defer func() {
 			if err := recover(); err != nil {
-				panicced = true
+				panicked = true
 			}
 		}()
 		_ = e.Render(nil)
-		if !panicced {
+		if !panicked {
 			t.FailNow()
 		}
 	})
 
 	t.Run("panics on direct string", func(t *testing.T) {
-		e := g.Group(nil)
-		panicced := false
+		e := g.Group(nil).(fmt.Stringer)
+		panicked := false
 		defer func() {
 			if err := recover(); err != nil {
-				panicced = true
+				panicked = true
 			}
 		}()
-		_ = fmt.Sprintf("%v", e)
-		if !panicced {
+		e.String()
+		if !panicked {
 			t.FailNow()
 		}
 	})

--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -155,4 +155,18 @@ func TestGroup(t *testing.T) {
 			t.FailNow()
 		}
 	})
+
+	t.Run("panics on direct string", func(t *testing.T) {
+		e := g.Group(nil)
+		panicced := false
+		defer func() {
+			if err := recover(); err != nil {
+				panicced = true
+			}
+		}()
+		e.String()
+		if !panicced {
+			t.FailNow()
+		}
+	})
 }

--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -1,6 +1,7 @@
 package gomponents_test
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -109,9 +110,21 @@ func TestEl(t *testing.T) {
 	})
 
 	t.Run("does not fail on nil node", func(t *testing.T) {
-		e := g.El("div", g.El("span"), nil, g.El("span"))
+		e := g.El("div", nil, g.El("span"), nil, g.El("span"))
 		assert.Equal(t, `<div><span /><span /></div>`, e)
 	})
+
+	t.Run("returns render error on cannot write", func(t *testing.T) {
+		e := g.El("div")
+		err := e.Render(&erroringWriter{})
+		assert.Error(t, err)
+	})
+}
+
+type erroringWriter struct{}
+
+func (w *erroringWriter) Write(p []byte) (n int, err error) {
+	return 0, errors.New("no thanks")
 }
 
 func TestText(t *testing.T) {

--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -177,7 +177,7 @@ func TestGroup(t *testing.T) {
 				panicced = true
 			}
 		}()
-		e.String()
+		_ = fmt.Sprintf("%v", e)
 		if !panicced {
 			t.FailNow()
 		}

--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -177,7 +177,7 @@ func TestGroup(t *testing.T) {
 				panicked = true
 			}
 		}()
-		e.String()
+		_ = e.String()
 		if !panicked {
 			t.FailNow()
 		}


### PR DESCRIPTION
The Render function has been changed to take a `Writer` instead of returning a string. This makes it possible to generate documents without having the whole content in memory.