### PR TITLE
Add NodeType which replaces the Placer interface

### DIFF
--- a/attr/attributes.go
+++ b/attr/attributes.go
@@ -26,8 +26,8 @@ func (c Classes) Render(w io.Writer) error {
 	return g.Attr("class", strings.Join(included, " ")).Render(w)
 }
 
-func (c Classes) Place() g.Placement {
-	return g.Inside
+func (c Classes) Type() g.NodeType {
+	return g.AttributeType
 }
 
 // String satisfies fmt.Stringer.


### PR DESCRIPTION
It was a weird interface that tried to abstract away nodes being elements or attributes, but it doesn't really make sense. Now `Nodes` just have a `NodeType`.