### PR TITLE
Fix TailwindCSS CDN URL in example

### DIFF
--- a/examples/tailwindcss/tailwindcss.go
+++ b/examples/tailwindcss/tailwindcss.go
@@ -51,10 +51,10 @@ func Page(title, path string, body g.Node) g.Node {
 		Title:    title,
 		Language: "en",
 		Head: []g.Node{
-			Link(Rel("stylesheet"), Href("https://unpkg.com/tailwindcss@^2.1.x/dist/base.min.css")),
-			Link(Rel("stylesheet"), Href("https://unpkg.com/tailwindcss@^2.1.x/dist/components.min.css")),
-			Link(Rel("stylesheet"), Href("https://unpkg.com/@tailwindcss/typography@0.4.x/dist/typography.min.css")),
-			Link(Rel("stylesheet"), Href("https://unpkg.com/tailwindcss@^2.1.x/dist/utilities.min.css")),
+			Link(Rel("stylesheet"), Href("https://unpkg.com/tailwindcss@2.1.2/dist/base.min.css")),
+			Link(Rel("stylesheet"), Href("https://unpkg.com/tailwindcss@2.1.2/dist/components.min.css")),
+			Link(Rel("stylesheet"), Href("https://unpkg.com/@tailwindcss/typography@0.4.0/dist/typography.min.css")),
+			Link(Rel("stylesheet"), Href("https://unpkg.com/tailwindcss@2.1.2/dist/utilities.min.css")),
 		},
 		Body: []g.Node{
 			Navbar(path, []PageLink{


### PR DESCRIPTION
The CSS style URLs from unpkg.com redirected to a different page, but the first request set a `Content-Type` header of `text/plain`. Using the direct URLs fixes this.

Fixes #75. Thanks to @gedw99 for reporting.