### PR TITLE
Escape Attr values

### DIFF
--- a/gomponents.go
+++ b/gomponents.go
@@ -66,8 +66,6 @@ func El(name string, children ...Node) Node {
 	return NodeFunc(func(w2 io.Writer) error {
 		w := &statefulWriter{w: w2}
 
-		name = template.HTMLEscapeString(name)
-
 		w.Write([]byte("<" + name))
 
 		for _, c := range children {
@@ -159,10 +157,10 @@ type attr struct {
 
 func (a *attr) Render(w io.Writer) error {
 	if a.value == nil {
-		_, err := w.Write([]byte(" " + template.HTMLEscapeString(a.name)))
+		_, err := w.Write([]byte(" " + a.name))
 		return err
 	}
-	_, err := w.Write([]byte(" " + template.HTMLEscapeString(a.name) + `="` + template.HTMLEscapeString(*a.value) + `"`))
+	_, err := w.Write([]byte(" " + a.name + `="` + template.HTMLEscapeString(*a.value) + `"`))
 	return err
 }
 

--- a/gomponents.go
+++ b/gomponents.go
@@ -66,6 +66,8 @@ func El(name string, children ...Node) Node {
 	return NodeFunc(func(w2 io.Writer) error {
 		w := &statefulWriter{w: w2}
 
+		name = template.HTMLEscapeString(name)
+
 		w.Write([]byte("<" + name))
 
 		for _, c := range children {
@@ -157,10 +159,10 @@ type attr struct {
 
 func (a *attr) Render(w io.Writer) error {
 	if a.value == nil {
-		_, err := w.Write([]byte(" " + a.name))
+		_, err := w.Write([]byte(" " + template.HTMLEscapeString(a.name)))
 		return err
 	}
-	_, err := w.Write([]byte(" " + a.name + `="` + *a.value + `"`))
+	_, err := w.Write([]byte(" " + template.HTMLEscapeString(a.name) + `="` + template.HTMLEscapeString(*a.value) + `"`))
 	return err
 }
 

--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -147,6 +147,15 @@ func TestEl(t *testing.T) {
 	})
 }
 
+func BenchmarkEl(b *testing.B) {
+	b.Run("normal elements", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			e := g.El("div")
+			_ = e.Render(&strings.Builder{})
+		}
+	})
+}
+
 type erroringWriter struct{}
 
 func (w *erroringWriter) Write(p []byte) (n int, err error) {

--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -55,14 +55,9 @@ func TestAttr(t *testing.T) {
 		}
 	})
 
-	t.Run("escapes attribute names", func(t *testing.T) {
-		a := g.Attr(`"><script`)
-		assert.Equal(t, ` &#34;&gt;&lt;script`, a)
-	})
-
-	t.Run("escapes attribute names and values", func(t *testing.T) {
-		a := g.Attr(`"><script`, `hat"><script`)
-		assert.Equal(t, ` &#34;&gt;&lt;script="hat&#34;&gt;&lt;script"`, a)
+	t.Run("escapes attribute values", func(t *testing.T) {
+		a := g.Attr(`id`, `hat"><script`)
+		assert.Equal(t, ` id="hat&#34;&gt;&lt;script"`, a)
 	})
 }
 
@@ -139,11 +134,6 @@ func TestEl(t *testing.T) {
 		e := g.El("div")
 		err := e.Render(&erroringWriter{})
 		assert.Error(t, err)
-	})
-
-	t.Run("escapes tag names", func(t *testing.T) {
-		e := g.El(`div><script`)
-		assert.Equal(t, `<div&gt;&lt;script></div&gt;&lt;script>`, e)
 	})
 }
 

--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -54,6 +54,16 @@ func TestAttr(t *testing.T) {
 			t.FailNow()
 		}
 	})
+
+	t.Run("escapes attribute names", func(t *testing.T) {
+		a := g.Attr(`"><script`)
+		assert.Equal(t, ` &#34;&gt;&lt;script`, a)
+	})
+
+	t.Run("escapes attribute names and values", func(t *testing.T) {
+		a := g.Attr(`"><script`, `hat"><script`)
+		assert.Equal(t, ` &#34;&gt;&lt;script="hat&#34;&gt;&lt;script"`, a)
+	})
 }
 
 func BenchmarkAttr(b *testing.B) {
@@ -129,6 +139,11 @@ func TestEl(t *testing.T) {
 		e := g.El("div")
 		err := e.Render(&erroringWriter{})
 		assert.Error(t, err)
+	})
+
+	t.Run("escapes tag names", func(t *testing.T) {
+		e := g.El(`div><script`)
+		assert.Equal(t, `<div&gt;&lt;script></div&gt;&lt;script>`, e)
 	})
 }
 


### PR DESCRIPTION
Because this can be a place of injection if untrusted data is passed, escape all attribute values.

This slows down rendering a bit, but we're still talking tiny increments compared to everything else.

### Before

```
$ make benchmark
go test -bench=.
goos: darwin
goarch: arm64
pkg: github.com/maragudk/gomponents
BenchmarkAttr/boolean_attributes-8         	13095948	        91.92 ns/op
BenchmarkAttr/name-value_attributes-8      	 9124303	       131.5 ns/op
BenchmarkEl/normal_elements-8              	 6384505	       187.4 ns/op
PASS
ok  	github.com/maragudk/gomponents	5.124s
```

### After

```
$ make benchmark
go test -bench=.
goos: darwin
goarch: arm64
pkg: github.com/maragudk/gomponents
BenchmarkAttr/boolean_attributes-8         	11524586	        92.07 ns/op
BenchmarkAttr/name-value_attributes-8      	 7606478	       157.0 ns/op
BenchmarkEl/normal_elements-8              	 6390315	       187.0 ns/op
PASS
ok  	github.com/maragudk/gomponents	4.000s
```

See #74.