### PR TITLE
Add Lazy type

### DIFF
--- a/gomponents.go
+++ b/gomponents.go
@@ -235,3 +235,12 @@ func If(condition bool, n Node) Node {
 	}
 	return nil
 }
+
+// Func is a function that returns a Node that is itself also a Node.
+// Used with If, it enables lazy evaluation of the node to return, depending on the condition passed to If.
+type Func func() Node
+
+// Render implements Node.
+func (f Func) Render(w io.Writer) error {
+	return f().Render(w)
+}

--- a/gomponents.go
+++ b/gomponents.go
@@ -242,11 +242,11 @@ func If(condition bool, n Node) Node {
 	return nil
 }
 
-// Func is a function that returns a Node that is itself also a Node.
+// Lazy is a function that returns a Node that is itself also a Node.
 // Used with If, it enables lazy evaluation of the node to return, depending on the condition passed to If.
-type Func func() Node
+type Lazy func() Node
 
 // Render implements Node.
-func (f Func) Render(w io.Writer) error {
-	return f().Render(w)
+func (l Lazy) Render(w io.Writer) error {
+	return l().Render(w)
 }

--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -292,19 +292,19 @@ func ExampleIf() {
 	// Output: <div><span>You lost your hat!</span></div>
 }
 
-func TestFunc(t *testing.T) {
-	t.Run("Func is a function type that is also a Node", func(t *testing.T) {
-		n := g.Func(func() g.Node {
+func TestLazy(t *testing.T) {
+	t.Run("Lazy is a function type that is also a Node", func(t *testing.T) {
+		n := g.Lazy(func() g.Node {
 			return g.El("div")
 		})
 		assert.Equal(t, "<div></div>", n)
 	})
 }
 
-func ExampleIf_func() {
+func ExampleIf_lazy() {
 	var message *string
 	e := g.El("div",
-		g.If(message != nil, g.Func(func() g.Node {
+		g.If(message != nil, g.Lazy(func() g.Node {
 			return g.El("span", g.Text(*message))
 		})),
 	)

--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -291,3 +291,23 @@ func ExampleIf() {
 	_ = e.Render(os.Stdout)
 	// Output: <div><span>You lost your hat!</span></div>
 }
+
+func TestFunc(t *testing.T) {
+	t.Run("Func is a function type that is also a Node", func(t *testing.T) {
+		n := g.Func(func() g.Node {
+			return g.El("div")
+		})
+		assert.Equal(t, "<div></div>", n)
+	})
+}
+
+func ExampleIf_func() {
+	var message *string
+	e := g.El("div",
+		g.If(message != nil, g.Func(func() g.Node {
+			return g.El("span", g.Text(*message))
+		})),
+	)
+	_ = e.Render(os.Stdout)
+	// Output: <div></div>
+}

--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -294,10 +294,21 @@ func ExampleIf() {
 
 func TestLazy(t *testing.T) {
 	t.Run("Lazy is a function type that is also a Node", func(t *testing.T) {
-		n := g.Lazy(func() g.Node {
-			return g.El("div")
-		})
-		assert.Equal(t, "<div></div>", n)
+		n := g.El("div",
+			g.Lazy(func() g.Node {
+				return g.El("span")
+			}),
+		)
+		assert.Equal(t, "<div><span></span></div>", n)
+	})
+
+	t.Run("Lazy also works for attribute type nodes", func(t *testing.T) {
+		n := g.El("div",
+			g.Lazy(func() g.Node {
+				return g.Attr("class", "foo")
+			}),
+		)
+		assert.Equal(t, "<input disabled>", n)
 	})
 }
 


### PR DESCRIPTION
`Lazy` is a function that returns a `Node` that is itself also a `Node`.

Used with `If`, it enables lazy evaluation of the node to return, depending on the condition passed to `If`.

See also #99 for a different approach explored.