### PR TITLE
[feat] Replace `Map` with a generic implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
     strategy:
       matrix:
         go:
-          - 1.16
-          - 1.17
           - 1.18
 
     steps:

--- a/examples/simple/simple.go
+++ b/examples/simple/simple.go
@@ -58,8 +58,8 @@ func Navbar(currentPath string, links []PageLink) g.Node {
 		Ul(
 			NavbarLink("/", "Home", currentPath),
 
-			g.Group(g.Map(len(links), func(i int) g.Node {
-				return NavbarLink(links[i].Path, links[i].Name, currentPath)
+			g.Group(g.Map(links, func(pl PageLink, _ int) g.Node {
+				return NavbarLink(pl.Path, pl.Name, currentPath)
 			})),
 		),
 

--- a/examples/tailwindcss/tailwindcss.go
+++ b/examples/tailwindcss/tailwindcss.go
@@ -81,8 +81,8 @@ func Navbar(currentPath string, links []PageLink) g.Node {
 				NavbarLink("/", "Home", currentPath == "/"),
 
 				// We can Map custom slices to Nodes
-				g.Group(g.Map(len(links), func(i int) g.Node {
-					return NavbarLink(links[i].Path, links[i].Name, currentPath == links[i].Path)
+				g.Group(g.Map(links, func(pl PageLink, _ int) g.Node {
+					return NavbarLink(pl.Path, pl.Name, currentPath == pl.Path)
 				})),
 			),
 		),

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module "github.com/maragudk/gomponents"
 
-go 1.15
+go 1.18

--- a/gomponents.go
+++ b/gomponents.go
@@ -245,10 +245,10 @@ func Group(children []Node) Node {
 }
 
 // Map something enumerable to a list of Nodes.
-func Map(length int, cb func(i int) Node) []Node {
+func Map[T any](items []T, mapper func(T, int) Node) []Node {
 	var nodes []Node
-	for i := 0; i < length; i++ {
-		nodes = append(nodes, cb(i))
+	for i, item := range items {
+		nodes = append(nodes, mapper(item, i))
 	}
 	return nodes
 }

--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -251,8 +251,8 @@ func TestGroup(t *testing.T) {
 func TestMap(t *testing.T) {
 	t.Run("maps slices to nodes", func(t *testing.T) {
 		items := []string{"hat", "partyhat", "turtlehat"}
-		lis := g.Map(len(items), func(i int) g.Node {
-			return g.El("li", g.Text(items[i]))
+		lis := g.Map(items, func(item string, _ int) g.Node {
+			return g.El("li", g.Text(item))
 		})
 
 		list := g.El("ul", lis...)
@@ -262,10 +262,12 @@ func TestMap(t *testing.T) {
 }
 
 func ExampleMap() {
-	items := []string{"party hat", "super hat"}
-	e := g.El("ul", g.Group(g.Map(len(items), func(i int) g.Node {
-		return g.El("li", g.Text(items[i]))
-	})))
+	e := g.El("ul", g.Group(g.Map(
+		[]string{"party hat", "super hat"},
+		func(item string, _ int) g.Node {
+			return g.El("li", g.Text(item))
+		},
+	)))
 	_ = e.Render(os.Stdout)
 	// Output: <ul><li>party hat</li><li>super hat</li></ul>
 }


### PR DESCRIPTION
Hello! :)

Based off this passage in your introductory blog post:

> Unfortunately, we don't have the handy map function like in Javascript (until we get generics 🤞)
> \- https://www.maragu.dk/blog/gomponents-declarative-view-components-in-go/

I replaced the implementation of `Map` with a generic one that's (in my opinion) easier to use than the previous. The examples and tests have also been updated to match. The CI test runner has also had versions of Go prior to 1.18 removed from the testing matrix.

A couple of things to consider:
 * This is very much a breaking change
 * This bumps the minimum required Go version from 1.15 to 1.18

Thanks!