### PR TITLE
Allow for groups to be rendered

### DIFF
--- a/gomponents.go
+++ b/gomponents.go
@@ -237,12 +237,21 @@ type group struct {
 
 // String satisfies fmt.Stringer.
 func (g group) String() string {
-	panic("cannot render group directly")
+	var b strings.Builder
+	_ = g.Render(&b)
+	return b.String()
 }
 
 // Render satisfies Node.
-func (g group) Render(io.Writer) error {
-	panic("cannot render group directly")
+func (g group) Render(w io.Writer) error {
+	for _, node := range g.children {
+		err := node.Render(w)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Group multiple Nodes into one Node. Useful for concatenation of Nodes in variadic functions.


### PR DESCRIPTION
Hey Markus,

What do you think about allowing groups to be rendered? I ran into this problem several times, while doing stuff like this:

```go
[…]
Td(g.Group(g.Map(subsidiaries, func(subsidiary models.Entity) g.Node {
	return g.Group([]g.Node{
		A(Href(fmt.Sprintf("/entity/%d", subsidiary.Entity_ID)),
			g.Textf("%d: %s (%s)", subsidiary.Entity_ID, subsidiary.Name, subsidiary.Country),
		),
		Br(),
	})
})))
[…]
```

Also, this limitation often stands in the way of straightforwardly extracting components into their own functions. You always have to have a wrapper, even when it does not make much sense.

It is pretty easy to add group rendering support, so maybe there is something I missed. What was the rationale for not allowing it in the first place? Are there deeper implications of this change I missed?