### PR TITLE
Fix wrong codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "examples"
+  - "internal/assert"


### PR DESCRIPTION
We don't need coverage for the example code and internal testing helpers.