### PR TITLE
Add dir

### DIFF
--- a/html/attributes.go
+++ b/html/attributes.go
@@ -270,3 +270,7 @@ func Width(v string) g.Node {
 func EncType(v string) g.Node {
 	return g.Attr("enctype", v)
 }
+
+func Dir(v string) g.Node {
+	return g.Attr("dir", v)
+}

--- a/html/attributes_test.go
+++ b/html/attributes_test.go
@@ -55,6 +55,7 @@ func TestSimpleAttributes(t *testing.T) {
 		{Name: "content", Func: Content},
 		{Name: "crossorigin", Func: CrossOrigin},
 		{Name: "enctype", Func: EncType},
+		{Name: "dir", Func: Dir},
 		{Name: "for", Func: For},
 		{Name: "form", Func: FormAttr},
 		{Name: "height", Func: Height},


### PR DESCRIPTION
`dir` is a global attribute that lets you specify whether text is RTL or LTR or if it should be determined by the browser.

Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir