### PR TITLE
Add datetime attribute

### DIFF
--- a/html/attributes.go
+++ b/html/attributes.go
@@ -28,6 +28,10 @@ func CrossOrigin(v string) g.Node {
 	return g.Attr("crossorigin", v)
 }
 
+func DateTime(v string) g.Node {
+	return g.Attr("datetime", v)
+}
+
 func Defer() g.Node {
 	return g.Attr("defer")
 }

--- a/html/attributes_test.go
+++ b/html/attributes_test.go
@@ -54,6 +54,7 @@ func TestSimpleAttributes(t *testing.T) {
 		{Name: "colspan", Func: ColSpan},
 		{Name: "content", Func: Content},
 		{Name: "crossorigin", Func: CrossOrigin},
+		{Name: "datetime", Func: DateTime},
 		{Name: "enctype", Func: EncType},
 		{Name: "dir", Func: Dir},
 		{Name: "for", Func: For},


### PR DESCRIPTION
`<time>`, `<del>` and `<ins>` can receive a [`datetime`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTimeElement/dateTime) attribute