### PR TITLE
Add new `Hreff` attribute function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /cover.out
+.idea

--- a/html/attributes.go
+++ b/html/attributes.go
@@ -1,6 +1,8 @@
 package html
 
 import (
+	"fmt"
+
 	g "github.com/maragudk/gomponents"
 )
 
@@ -143,6 +145,10 @@ func Height(v string) g.Node {
 
 func Href(v string) g.Node {
 	return g.Attr("href", v)
+}
+
+func Hreff(format string, a ...any) g.Node {
+	return g.Attr("href", fmt.Sprintf(format, a...))
 }
 
 func ID(v string) g.Node {

--- a/html/attributes_test.go
+++ b/html/attributes_test.go
@@ -120,3 +120,10 @@ func TestData(t *testing.T) {
 		assert.Equal(t, ` data-id="partyhat"`, n)
 	})
 }
+
+func TestHreff(t *testing.T) {
+	t.Run("formats href value", func(t *testing.T) {
+		assert.Equal(t, ` href="no-args"`, Hreff("no-args"))
+		assert.Equal(t, ` href="/prefix/123/suffix/test"`, Hreff("/prefix/%d/suffix/%s", 123, "test"))
+	})
+}


### PR DESCRIPTION
Hey there, I've written this enough times and I feel like it makes sense to have that quality of life function. Do you think that it would be useful to add it to the library itself to save a few key strokes?

---

Hreff allows formatting the attribute value with arguments, like `fmt`. So instead of writing:

```golang
Href(fmt.Sprintf("/some-path/%d", obj.ID))
```

You can directly format the path:

```golang
Hreff("/some-path/%d", obj.ID)
```