### PR TITLE
Move module to maragu.dev/gomponents namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ _gomponents_ are HTML components written in pure Go.
 They render to HTML 5, and make it easy for you to build reusable components.
 So you can focus on building your app instead of learning yet another templating language.
 
-The API may change until version 1 is reached.
+```shell
+go get maragu.dev/gomponents
+```
 
 Made with ✨sparkles✨ by [maragu](https://www.maragu.dev/).
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 <img src="logo.png" alt="Logo" width="300" align="right"/>
 
-[![GoDoc](https://pkg.go.dev/badge/github.com/maragudk/gomponents)](https://pkg.go.dev/github.com/maragudk/gomponents)
+[![GoDoc](https://pkg.go.dev/badge/maragu.dev/gomponents)](https://pkg.go.dev/maragu.dev/gomponents)
 [![Go](https://github.com/maragudk/gomponents/actions/workflows/ci.yml/badge.svg)](https://github.com/maragudk/gomponents/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/maragudk/gomponents/branch/main/graph/badge.svg)](https://codecov.io/gh/maragudk/gomponents)
-[![Go Report Card](https://goreportcard.com/badge/github.com/maragudk/gomponents)](https://goreportcard.com/report/github.com/maragudk/gomponents)
+[![Go Report Card](https://goreportcard.com/badge/maragu.dev/gomponents)](https://goreportcard.com/report/maragu.dev/gomponents)
 
 Try HTML components in pure Go.
 
@@ -40,7 +40,7 @@ Check out [www.gomponents.com](https://www.gomponents.com) for an introduction.
 ## Usage
 
 ```shell
-go get github.com/maragudk/gomponents
+go get maragu.dev/gomponents
 ```
 
 The preferred way to use gomponents is with so-called dot-imports (note the dot before the imports),
@@ -50,9 +50,9 @@ to give you that smooth, native HTML feel:
 package main
 
 import (
-	. "github.com/maragudk/gomponents"
-	. "github.com/maragudk/gomponents/components"
-	. "github.com/maragudk/gomponents/html"
+	. "maragu.dev/gomponents"
+	. "maragu.dev/gomponents/components"
+	. "maragu.dev/gomponents/html"
 )
 
 func Navbar(authenticated bool, currentPath string) Node {

--- a/components/components.go
+++ b/components/components.go
@@ -6,8 +6,8 @@ import (
 	"sort"
 	"strings"
 
-	g "github.com/maragudk/gomponents"
-	. "github.com/maragudk/gomponents/html"
+	g "maragu.dev/gomponents"
+	. "maragu.dev/gomponents/html"
 )
 
 // HTML5Props for [HTML5].

--- a/components/components_test.go
+++ b/components/components_test.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"testing"
 
-	g "github.com/maragudk/gomponents"
-	. "github.com/maragudk/gomponents/components"
-	. "github.com/maragudk/gomponents/html"
-	"github.com/maragudk/gomponents/internal/assert"
+	g "maragu.dev/gomponents"
+	. "maragu.dev/gomponents/components"
+	. "maragu.dev/gomponents/html"
+	"maragu.dev/gomponents/internal/assert"
 )
 
 func TestHTML5(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module "github.com/maragudk/gomponents"
+module "maragu.dev/gomponents"
 
 go 1.18

--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	g "github.com/maragudk/gomponents"
-	"github.com/maragudk/gomponents/internal/assert"
+	g "maragu.dev/gomponents"
+	"maragu.dev/gomponents/internal/assert"
 )
 
 func TestNodeFunc(t *testing.T) {

--- a/html/attributes.go
+++ b/html/attributes.go
@@ -1,7 +1,7 @@
 package html
 
 import (
-	g "github.com/maragudk/gomponents"
+	g "maragu.dev/gomponents"
 )
 
 func Async() g.Node {

--- a/html/attributes_test.go
+++ b/html/attributes_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	g "github.com/maragudk/gomponents"
-	. "github.com/maragudk/gomponents/html"
-	"github.com/maragudk/gomponents/internal/assert"
+	g "maragu.dev/gomponents"
+	. "maragu.dev/gomponents/html"
+	"maragu.dev/gomponents/internal/assert"
 )
 
 func TestBooleanAttributes(t *testing.T) {

--- a/html/elements.go
+++ b/html/elements.go
@@ -8,7 +8,7 @@ package html
 import (
 	"io"
 
-	g "github.com/maragudk/gomponents"
+	g "maragu.dev/gomponents"
 )
 
 // Doctype returns a special kind of [g.Node] that prefixes its sibling with the string "<!doctype html>".

--- a/html/elements_test.go
+++ b/html/elements_test.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	g "github.com/maragudk/gomponents"
-	. "github.com/maragudk/gomponents/html"
-	"github.com/maragudk/gomponents/internal/assert"
+	g "maragu.dev/gomponents"
+	. "maragu.dev/gomponents/html"
+	"maragu.dev/gomponents/internal/assert"
 )
 
 type erroringWriter struct{}

--- a/http/handler.go
+++ b/http/handler.go
@@ -4,7 +4,7 @@ package http
 import (
 	"net/http"
 
-	g "github.com/maragudk/gomponents"
+	g "maragu.dev/gomponents"
 )
 
 // Handler is like [http.Handler] but returns a [g.Node] and an error.

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	g "github.com/maragudk/gomponents"
-	ghttp "github.com/maragudk/gomponents/http"
+	g "maragu.dev/gomponents"
+	ghttp "maragu.dev/gomponents/http"
 )
 
 func TestAdapt(t *testing.T) {

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	g "github.com/maragudk/gomponents"
+	g "maragu.dev/gomponents"
 )
 
 // Equal checks for equality between the given expected string and the rendered Node string.


### PR DESCRIPTION
This is a breaking change to move gomponents to my own import namespace.

I will obviously be careful with this, test it out in all kinds of scenarios, release betas, etc. But otherwise, because the `Node` interface is so simple and has basically never changed, I don't think this will break much. 🤞

Fixes #200