### PR TITLE
Handle void tags with different render function

### DIFF
--- a/gomponents_test.go
+++ b/gomponents_test.go
@@ -75,7 +75,7 @@ func BenchmarkAttr(b *testing.B) {
 }
 
 func ExampleAttr_bool() {
-	e := g.El("input", g.Attr("required"))
+	e := g.VoidEl("input", g.Attr("required"))
 	_ = e.Render(os.Stdout)
 	// Output: <input required>
 }
@@ -104,13 +104,13 @@ func TestEl(t *testing.T) {
 	})
 
 	t.Run("renders an empty element without closing tag if it's a void kind element", func(t *testing.T) {
-		e := g.El("hr")
+		e := g.VoidEl("hr")
 		assert.Equal(t, "<hr>", e)
 
-		e = g.El("br")
+		e = g.VoidEl("br")
 		assert.Equal(t, "<br>", e)
 
-		e = g.El("img")
+		e = g.VoidEl("img")
 		assert.Equal(t, "<img>", e)
 	})
 
@@ -120,12 +120,12 @@ func TestEl(t *testing.T) {
 	})
 
 	t.Run("renders an element, attributes, and element children", func(t *testing.T) {
-		e := g.El("div", g.Attr("class", "hat"), g.El("br"))
+		e := g.El("div", g.Attr("class", "hat"), g.VoidEl("br"))
 		assert.Equal(t, `<div class="hat"><br></div>`, e)
 	})
 
 	t.Run("renders attributes at the correct place regardless of placement in parameter list", func(t *testing.T) {
-		e := g.El("div", g.El("br"), g.Attr("class", "hat"))
+		e := g.El("div", g.VoidEl("br"), g.Attr("class", "hat"))
 		assert.Equal(t, `<div class="hat"><br></div>`, e)
 	})
 
@@ -135,7 +135,7 @@ func TestEl(t *testing.T) {
 	})
 
 	t.Run("does not fail on nil node", func(t *testing.T) {
-		e := g.El("div", nil, g.El("br"), nil, g.El("br"))
+		e := g.El("div", nil, g.VoidEl("br"), nil, g.VoidEl("br"))
 		assert.Equal(t, `<div><br><br></div>`, e)
 	})
 
@@ -265,8 +265,8 @@ func ExampleMap_index() {
 
 func TestGroup(t *testing.T) {
 	t.Run("groups multiple nodes into one", func(t *testing.T) {
-		children := []g.Node{g.El("br", g.Attr("id", "hat")), g.El("hr")}
-		e := g.El("div", g.Attr("class", "foo"), g.El("img"), g.Group(children))
+		children := []g.Node{g.VoidEl("br", g.Attr("id", "hat")), g.VoidEl("hr")}
+		e := g.El("div", g.Attr("class", "foo"), g.VoidEl("img"), g.Group(children))
 		assert.Equal(t, `<div class="foo"><img><br id="hat"><hr></div>`, e)
 	})
 
@@ -277,7 +277,7 @@ func TestGroup(t *testing.T) {
 	})
 
 	t.Run("does not ignore attributes at the second level and below", func(t *testing.T) {
-		children := []g.Node{g.El("div", g.Attr("class", "hat"), g.El("hr", g.Attr("id", "partyhat"))), g.El("span")}
+		children := []g.Node{g.El("div", g.Attr("class", "hat"), g.VoidEl("hr", g.Attr("id", "partyhat"))), g.El("span")}
 		e := g.Group(children)
 		assert.Equal(t, `<div class="hat"><hr id="partyhat"></div><span></span>`, e)
 	})

--- a/html/elements.go
+++ b/html/elements.go
@@ -30,7 +30,7 @@ func Address(children ...g.Node) g.Node {
 }
 
 func Area(children ...g.Node) g.Node {
-	return g.El("area", children...)
+	return g.VoidEl("area", children...)
 }
 
 func Article(children ...g.Node) g.Node {
@@ -46,7 +46,7 @@ func Audio(children ...g.Node) g.Node {
 }
 
 func Base(children ...g.Node) g.Node {
-	return g.El("base", children...)
+	return g.VoidEl("base", children...)
 }
 
 func BlockQuote(children ...g.Node) g.Node {
@@ -58,7 +58,7 @@ func Body(children ...g.Node) g.Node {
 }
 
 func Br(children ...g.Node) g.Node {
-	return g.El("br", children...)
+	return g.VoidEl("br", children...)
 }
 
 func Button(children ...g.Node) g.Node {
@@ -83,11 +83,15 @@ func Code(children ...g.Node) g.Node {
 }
 
 func Col(children ...g.Node) g.Node {
-	return g.El("col", children...)
+	return g.VoidEl("col", children...)
 }
 
 func ColGroup(children ...g.Node) g.Node {
 	return g.El("colgroup", children...)
+}
+
+func Command(children ...g.Node) g.Node {
+	return g.El("command", children...)
 }
 
 func DataEl(children ...g.Node) g.Node {
@@ -115,7 +119,7 @@ func Dl(children ...g.Node) g.Node {
 }
 
 func Embed(children ...g.Node) g.Node {
-	return g.El("embed", children...)
+	return g.VoidEl("embed", children...)
 }
 
 func Form(children ...g.Node) g.Node {
@@ -152,7 +156,7 @@ func HGroup(children ...g.Node) g.Node {
 }
 
 func Hr(children ...g.Node) g.Node {
-	return g.El("hr", children...)
+	return g.VoidEl("hr", children...)
 }
 
 func HTML(children ...g.Node) g.Node {
@@ -164,11 +168,15 @@ func IFrame(children ...g.Node) g.Node {
 }
 
 func Img(children ...g.Node) g.Node {
-	return g.El("img", children...)
+	return g.VoidEl("img", children...)
 }
 
 func Input(children ...g.Node) g.Node {
-	return g.El("input", children...)
+	return g.VoidEl("input", children...)
+}
+
+func Keygen(children ...g.Node) g.Node {
+	return g.VoidEl("keygen", children...)
 }
 
 func Label(children ...g.Node) g.Node {
@@ -189,7 +197,7 @@ func Li(children ...g.Node) g.Node {
 }
 
 func Link(children ...g.Node) g.Node {
-	return g.El("link", children...)
+	return g.VoidEl("link", children...)
 }
 
 func Main(children ...g.Node) g.Node {
@@ -201,7 +209,7 @@ func Menu(children ...g.Node) g.Node {
 }
 
 func Meta(children ...g.Node) g.Node {
-	return g.El("meta", children...)
+	return g.VoidEl("meta", children...)
 }
 
 func Meter(children ...g.Node) g.Node {
@@ -237,7 +245,7 @@ func P(children ...g.Node) g.Node {
 }
 
 func Param(children ...g.Node) g.Node {
-	return g.El("param", children...)
+	return g.VoidEl("param", children...)
 }
 
 func Picture(children ...g.Node) g.Node {
@@ -265,7 +273,7 @@ func Select(children ...g.Node) g.Node {
 }
 
 func Source(children ...g.Node) g.Node {
-	return g.El("source", children...)
+	return g.VoidEl("source", children...)
 }
 
 func Span(children ...g.Node) g.Node {
@@ -316,12 +324,16 @@ func Tr(children ...g.Node) g.Node {
 	return g.El("tr", children...)
 }
 
+func Track(children ...g.Node) g.Node {
+	return g.VoidEl("tr", children...)
+}
+
 func Ul(children ...g.Node) g.Node {
 	return g.El("ul", children...)
 }
 
 func Wbr(children ...g.Node) g.Node {
-	return g.El("wbr", children...)
+	return g.VoidEl("wbr", children...)
 }
 
 func Abbr(children ...g.Node) g.Node {


### PR DESCRIPTION
# Context

* During rendering any tag `render` function will check if the tag name is void by looking it up from a map
* This means every tag has a small performance hit when rendered
* As the list of void tags is constant and doesn't change in runtime the decision of how to render can be taken in compile time

# Changes
* This PR removes the map of void tags
* Removes the condition to handle void tags in `render`
* Creates a new `VoidEl` function to create void tag node
* It creates a new `renderVoid` function which renders the tag without close tag.
* It changes the void tags functions to use `VoidEl` instead of `El` 
* And it adds a missing void tag functions that was in the map but didn't have a function (command, keygen, track)

Relevant [initial discussion](https://www.reddit.com/r/golang/comments/1g15g4a/comment/lrfz5kn/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button) 