### PR TITLE
Add support for additional HTML attributes in HTML5 template

### DIFF
--- a/components/components.go
+++ b/components/components.go
@@ -18,12 +18,13 @@ type HTML5Props struct {
 	Language    string
 	Head        []g.Node
 	Body        []g.Node
+	HTMLAttrs   []g.Node
 }
 
 // HTML5 document template.
 func HTML5(p HTML5Props) g.Node {
 	return Doctype(
-		HTML(g.If(p.Language != "", Lang(p.Language)),
+		HTML(g.If(p.Language != "", Lang(p.Language)), g.Group(p.HTMLAttrs),
 			Head(
 				Meta(Charset("utf-8")),
 				Meta(Name("viewport"), Content("width=device-width, initial-scale=1")),

--- a/components/components_test.go
+++ b/components/components_test.go
@@ -30,6 +30,19 @@ func TestHTML5(t *testing.T) {
 
 		assert.Equal(t, `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Hat</title></head><body></body></html>`, e)
 	})
+
+	t.Run("returns an html5 document template with additional HTML attributes", func(t *testing.T) {
+		e := HTML5(HTML5Props{
+			Title:       "Hat",
+			Description: "Love hats.",
+			Language:    "en",
+			Head:        []g.Node{Link(Rel("stylesheet"), Href("/hat.css"))},
+			Body:        []g.Node{Div()},
+			HTMLAttrs:   []g.Node{Class("h-full"), ID("htmlid")},
+		})
+
+		assert.Equal(t, `<!doctype html><html lang="en" class="h-full" id="htmlid"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Hat</title><meta name="description" content="Love hats."><link rel="stylesheet" href="/hat.css"></head><body><div></div></body></html>`, e)
+	})
 }
 
 func TestClasses(t *testing.T) {


### PR DESCRIPTION
This PR updates the HTML5 function to accept and render additional HTML attributes. An additional test case to validate this enhancement has been added as well.