### PR TITLE
Improve performance of `Map` and `Classes.Render` by preallocating slices

### DIFF
--- a/components/components.go
+++ b/components/components.go
@@ -44,7 +44,7 @@ type Classes map[string]bool
 
 // Render satisfies [g.Node].
 func (c Classes) Render(w io.Writer) error {
-	var included []string
+	included := make([]string, 0, len(c))
 	for c, include := range c {
 		if include {
 			included = append(included, c)

--- a/gomponents.go
+++ b/gomponents.go
@@ -250,7 +250,7 @@ func Rawf(format string, a ...interface{}) Node {
 
 // Map a slice of anything to a [Group] (which is just a slice of [Node]-s).
 func Map[T any](ts []T, cb func(T) Node) Group {
-	var nodes []Node
+	nodes := make([]Node, 0, len(ts))
 	for _, t := range ts {
 		nodes = append(nodes, cb(t))
 	}


### PR DESCRIPTION
Hey! I just discovered this repo and I love being able to write templates while still having compile-time checks.

I was looking through the code and noticed slices aren't currently preallocated in `Map()` and `Classes.Render()`. Preallocating will improve performance since the resulting slice won't have to be grown dynamically during the append loop.