### PR TITLE
Combine class attributes

### DIFF
--- a/gomponents.go
+++ b/gomponents.go
@@ -79,8 +79,35 @@ func El(name string, children ...Node) Node {
 	})
 }
 
+// Prevents class="" appearing twice.
+func combineChildren(children []Node) []Node {
+	var combined []Node
+
+	var foundClassAttr *attr
+
+	for _, child := range children {
+		p, ok := child.(*attr)
+
+		if ok && p.name == "class" {
+			*p.value = strings.TrimSpace(*p.value)
+			if foundClassAttr == nil {
+				foundClassAttr = p
+			} else {
+				*foundClassAttr.value += " " + *p.value
+				continue // dont append
+			}
+		}
+
+		combined = append(combined, child)
+	}
+
+	return combined
+}
+
 func render(w2 io.Writer, name *string, children ...Node) error {
 	w := &statefulWriter{w: w2}
+
+	children = combineChildren(children)
 
 	if name != nil {
 		w.Write([]byte("<" + *name))


### PR DESCRIPTION
Multiple `Class()`'s doesn't concatenate together. When using something like Tailwind, you can't easily add more classes from the parent element. Example below:

```go
func TestDiv(children ...Node) Node {
	return Div(append(
		[]Node{Class("test")},
		children...,
	)...)
}

func MainDiv() Node {
	return TestDiv(Class("main"))
}
```
Outputs invalid HTML:
```html
<div class="test" class="main"></div>
```
Should output:
```html
<div class="test main"></div>
```
I don't know if my implementation is the best way to do it, but it seems to work. Doesn't work with `Classes{}` yet though.