### PR TITLE
Add "search" HTML element

### DIFF
--- a/html/elements.go
+++ b/html/elements.go
@@ -256,6 +256,10 @@ func Script(children ...g.Node) g.Node {
 	return g.El("script", children...)
 }
 
+func Search(children ...g.Node) g.Node {
+	return g.El("search", children...)
+}
+
 func Section(children ...g.Node) g.Node {
 	return g.El("section", children...)
 }

--- a/html/elements_test.go
+++ b/html/elements_test.go
@@ -102,6 +102,7 @@ func TestSimpleElements(t *testing.T) {
 		{Name: "s", Func: S},
 		{Name: "samp", Func: Samp},
 		{Name: "script", Func: Script},
+		{Name: "search", Func: Search},
 		{Name: "section", Func: Section},
 		{Name: "select", Func: Select},
 		{Name: "slot", Func: SlotEl},


### PR DESCRIPTION
Hey there,

Thanks for this project! Super cool idea and I've been exploring using it to replace the standard `html/template` package in one of my Go projects.

One thing I noticed, however, is that the [search element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/search) appears to be missing. This PR adds it (and updates the tests, as well).

Please let me know if I've missed anything or if any changes should be made.

Thanks again!