### PR TITLE
Add `components.JoinAttrs`

### DIFF
--- a/LLMs.md
+++ b/LLMs.md
@@ -1,0 +1,524 @@
+# gomponents: HTML Components in Pure Go - LLM Documentation
+
+## Overview
+
+gomponents is a Go library that enables building HTML components using pure Go code. Instead of using traditional HTML templates, developers write HTML as Go functions that compile to type-safe, performant HTML5 output. This approach leverages Go's type system, IDE support, and debugging capabilities while avoiding template language complexity.
+
+## Core Concepts
+
+### Node Interface
+The fundamental building block is the `Node` interface:
+```go
+type Node interface {
+    Render(w io.Writer) error
+}
+```
+Everything in gomponents implements this interface - elements, attributes, text, and components.
+
+### Node Types
+- **ElementType**: Regular HTML elements (div, span, etc.) and text nodes
+- **AttributeType**: HTML attributes (class, href, etc.)
+
+The library automatically handles proper placement during rendering.
+
+## Installation
+
+```bash
+go get maragu.dev/gomponents
+```
+
+## Import Patterns
+
+### Dot imports (recommended):
+Contrary to common idiomatic Go, dot imports are the recommended approach for gomponents as they make the code read like a DSL for HTML:
+```go
+import (
+    . "maragu.dev/gomponents"
+    . "maragu.dev/gomponents/html"
+    . "maragu.dev/gomponents/components"
+)
+```
+
+### Standard imports with aliases (alternative):
+For those who prefer avoiding dot imports, use single-letter aliases:
+```go
+import (
+    g "maragu.dev/gomponents"
+    h "maragu.dev/gomponents/html"
+    c "maragu.dev/gomponents/components"
+    ghttp "maragu.dev/gomponents/http"
+)
+```
+
+## Package Structure
+
+### maragu.dev/gomponents (core)
+Core interfaces and helper functions:
+- `Node` interface
+- `El(name string, children ...Node)` - create custom elements
+- `Attr(name string, value ...string)` - create custom attributes
+- `Text(string)` - HTML-escaped text
+- `Textf(format string, args...)` - formatted escaped text
+- `Raw(string)` - unescaped HTML
+- `Rawf(format string, args...)` - formatted unescaped HTML
+- `Group([]Node)` - group multiple nodes
+- `Map[T]([]T, func(T) Node)` - transform slices to nodes
+- `If(condition bool, node Node)` - conditional rendering
+- `Iff(condition bool, func() Node)` - lazy conditional rendering
+
+### maragu.dev/gomponents/html
+All HTML5 elements and attributes as Go functions:
+- Elements: `Div()`, `Span()`, `A()`, `H1()`, etc.
+- Attributes: `Class()`, `ID()`, `Href()`, `Style()`, etc.
+- Special: `Doctype()` for HTML5 doctype declaration
+
+### maragu.dev/gomponents/components
+Higher-level components:
+- `HTML5(HTML5Props)` - complete HTML5 document structure
+- `Classes` - dynamic class management map
+
+### maragu.dev/gomponents/http
+HTTP handler integration:
+- `Handler` type - returns (Node, error)
+- `Adapt()` - converts Handler to http.HandlerFunc
+
+## Basic Usage Examples
+
+### Simple Element
+```go
+import (
+    . "maragu.dev/gomponents"
+    . "maragu.dev/gomponents/html"
+)
+
+// <div class="container">Hello, World!</div>
+Div(Class("container"), Text("Hello, World!"))
+```
+
+### Nested Structure
+```go
+import (
+    . "maragu.dev/gomponents"
+    . "maragu.dev/gomponents/html"
+)
+
+// <nav><a href="/">Home</a><a href="/about">About</a></nav>
+Nav(
+    A(Href("/"), Text("Home")),
+    A(Href("/about"), Text("About"))
+)
+```
+
+### Complete Page
+```go
+import (
+    . "maragu.dev/gomponents"
+    . "maragu.dev/gomponents/components"
+    . "maragu.dev/gomponents/html"
+)
+
+func Page() Node {
+    return HTML5(HTML5Props{
+        Title: "My Page",
+        Language: "en",
+        Head: []Node{
+            Meta(Name("author"), Content("John Doe")),
+        },
+        Body: []Node{
+            H1(Text("Welcome")),
+            P(Text("This is my page")),
+        },
+    })
+}
+```
+
+## Advanced Patterns
+
+### Component Functions
+Create reusable components as functions:
+```go
+import (
+    . "maragu.dev/gomponents"
+    . "maragu.dev/gomponents/html"
+)
+
+func Card(title, content string) Node {
+    return Div(Class("card"),
+        H2(Class("card-title"), Text(title)),
+        P(Class("card-content"), Text(content)),
+    )
+}
+```
+
+### Dynamic Rendering
+```go
+import (
+    . "maragu.dev/gomponents"
+    . "maragu.dev/gomponents/html"
+)
+
+func UserList(users []User) Node {
+    return Ul(
+        Map(users, func(u User) Node {
+            return Li(Text(u.Name))
+        }),
+    )
+}
+```
+
+### Conditional Rendering
+```go
+import (
+    . "maragu.dev/gomponents"
+    . "maragu.dev/gomponents/html"
+)
+
+func NavBar(isLoggedIn bool, username string) Node {
+    return Nav(
+        A(Href("/"), Text("Home")),
+        If(isLoggedIn, 
+            Span(Text("Welcome, " + username))),
+        If(!isLoggedIn,
+            A(Href("/login"), Text("Login"))),
+    )
+}
+```
+
+### Dynamic Classes
+```go
+import (
+    . "maragu.dev/gomponents"
+    . "maragu.dev/gomponents/components"
+    . "maragu.dev/gomponents/html"
+)
+
+Div(
+    Classes{
+        "active": isActive,
+        "disabled": isDisabled,
+        "primary": isPrimary,
+    },
+    Text("Dynamic styling"),
+)
+```
+
+## Special Elements and Attributes
+
+### Name Conflicts
+Some HTML names conflict in Go. The library provides both variants:
+- `Style()` (attribute) vs `StyleEl()` (element)
+- `Title()` (attribute) vs `TitleEl()` (element)
+- `Form()` (element) vs `FormAttr()` (attribute)
+- `Label()` (element) vs `LabelAttr()` (attribute)
+- `Data()` (attribute) vs `DataEl()` (element)
+- `Cite()` (element) vs `CiteAttr()` (attribute)
+
+### Void Elements
+Self-closing elements (br, img, input, etc.) are handled automatically. Child nodes that aren't attributes are ignored:
+```go
+// Correct: <img src="pic.jpg" alt="Picture">
+Img(Src("pic.jpg"), Alt("Picture"))
+
+// Text("ignored") won't render for void elements
+Img(Src("pic.jpg"), Text("ignored"))
+```
+
+## HTTP Integration
+
+### Basic Handler
+```go
+import (
+    "net/http"
+    
+    . "maragu.dev/gomponents"
+    . "maragu.dev/gomponents/html"
+    ghttp "maragu.dev/gomponents/http"
+)
+
+func HomeHandler(w http.ResponseWriter, r *http.Request) (Node, error) {
+    return Page("Welcome!"), nil
+}
+
+// In main:
+http.HandleFunc("/", ghttp.Adapt(HomeHandler))
+```
+
+### Error Handling
+```go
+import (
+    "net/http"
+    
+    . "maragu.dev/gomponents"
+    ghttp "maragu.dev/gomponents/http"
+)
+
+type HTTPError struct {
+    Code int
+    Message string
+}
+
+func (e HTTPError) Error() string { return e.Message }
+func (e HTTPError) StatusCode() int { return e.Code }
+
+func Handler(w http.ResponseWriter, r *http.Request) (Node, error) {
+    if unauthorized {
+        return ErrorPage(), HTTPError{Code: 401, Message: "Unauthorized"}
+    }
+    return SuccessPage(), nil
+}
+```
+
+## Best Practices
+
+### 1. Component Composition
+Build complex UIs from simple, reusable components:
+```go
+import (
+    . "maragu.dev/gomponents"
+    . "maragu.dev/gomponents/components"
+    . "maragu.dev/gomponents/html"
+)
+
+func Layout(title string, content Node) Node {
+    return HTML5(HTML5Props{
+        Title: title,
+        Body: []Node{
+            Header(),
+            Main(content),
+            Footer(),
+        },
+    })
+}
+```
+
+### 2. Type Safety
+Leverage Go's type system for compile-time guarantees:
+```go
+import (
+    . "maragu.dev/gomponents"
+    . "maragu.dev/gomponents/html"
+)
+
+type ButtonVariant string
+
+const (
+    ButtonPrimary   ButtonVariant = "btn-primary"
+    ButtonSecondary ButtonVariant = "btn-secondary"
+)
+
+func Button(variant ButtonVariant, text string) Node {
+    return Button(Class(string(variant)), Type("button"), Text(text))
+}
+```
+
+### 3. Performance
+Nodes render directly to io.Writer for efficiency:
+```go
+import (
+    "net/http"
+)
+
+// Efficient - streams directly to response
+func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    node := BuildPage()
+    node.Render(w)
+}
+```
+
+### 4. Testing
+Components are pure functions, making testing straightforward:
+```go
+import (
+    "bytes"
+    "testing"
+)
+
+func TestButton(t *testing.T) {
+    btn := Button("Click me")
+    
+    var buf bytes.Buffer
+    btn.Render(&buf)
+    
+    expected := `<button>Click me</button>`
+    if buf.String() != expected {
+        t.Errorf("got %q, want %q", buf.String(), expected)
+    }
+}
+```
+
+## Common Patterns
+
+### Forms
+```go
+import (
+    . "maragu.dev/gomponents"
+    . "maragu.dev/gomponents/html"
+)
+
+func LoginForm() Node {
+    return Form(Method("post"), Action("/login"),
+        Label(For("email"), Text("Email:")),
+        Input(Type("email"), ID("email"), Name("email"), Required()),
+        
+        Label(For("password"), Text("Password:")),
+        Input(Type("password"), ID("password"), Name("password"), Required()),
+        
+        Button(Type("submit"), Text("Login")),
+    )
+}
+```
+
+### Tables
+```go
+import (
+    . "maragu.dev/gomponents"
+    . "maragu.dev/gomponents/html"
+)
+
+func DataTable(headers []string, rows [][]string) Node {
+    return Table(
+        Thead(
+            Tr(Map(headers, func(h string) Node {
+                return Th(Text(h))
+            })),
+        ),
+        Tbody(
+            Map(rows, func(row []string) Node {
+                return Tr(Map(row, func(cell string) Node {
+                    return Td(Text(cell))
+                }))
+            }),
+        ),
+    )
+}
+```
+
+### Lists
+```go
+import (
+    . "maragu.dev/gomponents"
+    . "maragu.dev/gomponents/html"
+)
+
+func NavMenu(items []MenuItem) Node {
+    return Nav(
+        Ul(Class("nav-menu"),
+            Map(items, func(item MenuItem) Node {
+                return Li(
+                    A(Href(item.URL), Text(item.Label)),
+                )
+            }),
+        ),
+    )
+}
+```
+
+## Integration Tips
+
+### With CSS Frameworks
+Works seamlessly with Tailwind, Bootstrap, etc.:
+```go
+import (
+    . "maragu.dev/gomponents"
+    . "maragu.dev/gomponents/html"
+)
+
+// Tailwind CSS
+Div(Class("flex items-center justify-between p-4 bg-blue-500"))
+
+// Bootstrap
+Div(Class("container-fluid"),
+    Div(Class("row"),
+        Div(Class("col-md-6"), Text("Column 1")),
+        Div(Class("col-md-6"), Text("Column 2")),
+    ),
+)
+```
+
+### With JavaScript
+Include scripts and handle interactions:
+```go
+import (
+    . "maragu.dev/gomponents"
+    . "maragu.dev/gomponents/html"
+)
+
+Button(
+    Class("interactive-btn"),
+    ID("myButton"),
+    Text("Click me"),
+)
+
+Script(Raw(`
+    document.getElementById('myButton').addEventListener('click', () => {
+        alert('Clicked!');
+    });
+`))
+```
+
+### Custom Elements
+For web components or non-standard elements:
+```go
+import (
+    . "maragu.dev/gomponents"
+)
+
+// <my-component attr="value">Content</my-component>
+El("my-component", 
+    Attr("attr", "value"),
+    Text("Content"),
+)
+```
+
+## Debugging
+
+### String() Method
+All nodes implement String() for debugging:
+```go
+import (
+    "fmt"
+    
+    . "maragu.dev/gomponents"
+    . "maragu.dev/gomponents/html"
+)
+
+node := Div(Class("test"), Text("Hello"))
+fmt.Println(node) // <div class="test">Hello</div>
+```
+
+### Rendering to Buffer
+Test component output:
+```go
+import (
+    "bytes"
+)
+
+var buf bytes.Buffer
+err := node.Render(&buf)
+html := buf.String()
+```
+
+## Performance Considerations
+
+1. **Direct Rendering**: Nodes render directly to io.Writer without intermediate string allocation
+2. **No Reflection**: Pure function calls, no runtime reflection overhead
+3. **Compile-Time Safety**: Errors caught at compile time, not runtime
+4. **Zero Dependencies**: Core library has no external dependencies
+
+## Common Gotchas
+
+1. **Nil Nodes**: Nil nodes are safely ignored during rendering
+2. **Attribute Order**: Attributes render in the order they're specified
+3. **Escaping**: Use Text() for escaped content, Raw() for unescaped HTML
+4. **Void Elements**: Children (except attributes) are ignored for void elements
+
+## Summary
+
+gomponents provides a type-safe, performant way to generate HTML in Go applications. It's particularly well-suited for:
+- Server-side rendered web applications
+- API servers that return HTML
+- Static site generators
+- Email template generation
+- Any scenario where you need programmatic HTML generation with Go's type safety
+
+The library's philosophy emphasizes simplicity, type safety, and Go idioms over template languages, making it an excellent choice for Go developers who prefer staying within the Go ecosystem.

--- a/components/components.go
+++ b/components/components.go
@@ -64,3 +64,13 @@ func (c Classes) String() string {
 	_ = c.Render(&b)
 	return b.String()
 }
+
+func MergeClasses(children ...g.Node) g.Node {
+	var b strings.Builder
+	for _, n := range children {
+		if err := n.Render(&b); err != nil {
+			panic(err)
+		}
+	}
+	return nil
+}

--- a/components/components.go
+++ b/components/components.go
@@ -65,6 +65,81 @@ func (c Classes) String() string {
 	return b.String()
 }
 
-func MergeClasses(children ...g.Node) g.Node {
-	return nil
+// JoinAttrs with the given name only on the first level of the given nodes.
+// This means that attributes on non-direct descendants are ignored.
+// Attribute values are joined by spaces.
+// Note that this renders all first-level attributes to check whether they should be processed.
+func JoinAttrs(name string, children ...g.Node) g.Node {
+	var attrValues []string
+	var result []g.Node
+	firstAttrIndex := -1
+
+	// Process all children
+	for _, child := range children {
+		// Handle groups explicitly because they may contain attributes
+		if group, ok := child.(g.Group); ok {
+			for _, groupChild := range group {
+				isGivenAttr, attrValue := extractAttrValue(name, groupChild)
+				if !isGivenAttr || attrValue == "" {
+					result = append(result, groupChild)
+					continue
+				}
+
+				attrValues = append(attrValues, attrValue)
+				if firstAttrIndex == -1 {
+					firstAttrIndex = len(result)
+					result = append(result, nil)
+				}
+			}
+
+			continue
+		}
+
+		// Handle non-group nodes essentially the same way
+		isGivenAttr, attrValue := extractAttrValue(name, child)
+		if !isGivenAttr || attrValue == "" {
+			result = append(result, child)
+			continue
+		}
+
+		attrValues = append(attrValues, attrValue)
+		if firstAttrIndex == -1 {
+			firstAttrIndex = len(result)
+			result = append(result, nil)
+		}
+	}
+
+	// If no attributes were found, just return the result now
+	if firstAttrIndex == -1 {
+		return g.Group(result)
+	}
+
+	// Insert joined attribute at the position of the first attribute
+	result[firstAttrIndex] = g.Attr(name, strings.Join(attrValues, " "))
+	return g.Group(result)
+}
+
+type nodeTypeDescriber interface {
+	Type() g.NodeType
+}
+
+func extractAttrValue(name string, n g.Node) (bool, string) {
+	// Ignore everything that is not an attribute
+	if n, ok := n.(nodeTypeDescriber); !ok || n.Type() == g.ElementType {
+		return false, ""
+	}
+
+	var b strings.Builder
+	if err := n.Render(&b); err != nil {
+		return false, ""
+	}
+
+	rendered := b.String()
+	if !strings.HasPrefix(rendered, " "+name+`="`) || !strings.HasSuffix(rendered, `"`) {
+		return false, ""
+	}
+
+	v := strings.TrimPrefix(rendered, " "+name+`="`)
+	v = strings.TrimSuffix(v, `"`)
+	return true, v
 }

--- a/components/components.go
+++ b/components/components.go
@@ -66,11 +66,5 @@ func (c Classes) String() string {
 }
 
 func MergeClasses(children ...g.Node) g.Node {
-	var b strings.Builder
-	for _, n := range children {
-		if err := n.Render(&b); err != nil {
-			panic(err)
-		}
-	}
 	return nil
 }

--- a/components/components_test.go
+++ b/components/components_test.go
@@ -88,3 +88,17 @@ func TestJoinAttrs(t *testing.T) {
 		assert.Equal(t, `<div id="party-hat" class="party hat"><span id="party-hat-text" class="solid" class="gold">Yo.</span></div>`, n)
 	})
 }
+
+func myButton(children ...g.Node) g.Node {
+	return Div(JoinAttrs("class", g.Group(children), Class("button")))
+}
+
+func myPrimaryButton(text string) g.Node {
+	return myButton(Class("primary"), g.Text(text))
+}
+
+func ExampleJoinAttrs() {
+	danceButton := myPrimaryButton("Dance")
+	_ = danceButton.Render(os.Stdout)
+	// Output: <div class="primary button">Dance</div>
+}

--- a/components/components_test.go
+++ b/components/components_test.go
@@ -68,6 +68,21 @@ func TestClasses(t *testing.T) {
 	})
 }
 
+func hat(children ...g.Node) g.Node {
+	return Div(MergeClasses(g.Group(children), Class("hat")))
+}
+
+func partyHat(children ...g.Node) g.Node {
+	return hat(ID("party-hat"), Class("party"), g.Group(children))
+}
+
+func TestMergeClasses(t *testing.T) {
+	t.Run("merges classes", func(t *testing.T) {
+		n := partyHat(g.Text("Yo."))
+		assert.Equal(t, `<div id="party-hat" class="party hat">Yo.</div>`, n)
+	})
+}
+
 func ExampleClasses() {
 	e := g.El("div", Classes{"party-hat": true, "boring-hat": false})
 	_ = e.Render(os.Stdout)

--- a/components/components_test.go
+++ b/components/components_test.go
@@ -78,8 +78,8 @@ func partyHat(children ...g.Node) g.Node {
 
 func TestMergeClasses(t *testing.T) {
 	t.Run("merges classes", func(t *testing.T) {
-		n := partyHat(g.Text("Yo."))
-		assert.Equal(t, `<div id="party-hat" class="party hat">Yo.</div>`, n)
+		n := partyHat(Span(ID("party-hat-text"), Class("solid"), g.Text("Yo.")))
+		assert.Equal(t, `<div id="party-hat" class="party hat"><span id="party-hat-text" class="solid">Yo.</span></div>`, n)
 	})
 }
 

--- a/components/components_test.go
+++ b/components/components_test.go
@@ -84,13 +84,19 @@ func partyHat(children ...g.Node) g.Node {
 	return hat(ID("party-hat"), Class("party"), g.Group(children))
 }
 
-type brokenNode struct{}
+type brokenNode struct {
+	first bool
+}
 
-func (b brokenNode) Render(io.Writer) error {
+func (b *brokenNode) Render(io.Writer) error {
+	if !b.first {
+		return nil
+	}
+	b.first = false
 	return errors.New("oh no")
 }
 
-func (b brokenNode) Type() g.NodeType {
+func (b *brokenNode) Type() g.NodeType {
 	return g.AttributeType
 }
 
@@ -111,7 +117,7 @@ func TestJoinAttrs(t *testing.T) {
 	})
 
 	t.Run("ignores nodes that can't render", func(t *testing.T) {
-		n := Div(JoinAttrs("class", Class("party"), ID("hey"), brokenNode{}, Class("hat")))
+		n := Div(JoinAttrs("class", Class("party"), ID("hey"), &brokenNode{first: true}, Class("hat")))
 		assert.Equal(t, `<div class="party hat" id="hey"></div>`, n)
 	})
 }

--- a/components/components_test.go
+++ b/components/components_test.go
@@ -68,23 +68,23 @@ func TestClasses(t *testing.T) {
 	})
 }
 
+func ExampleClasses() {
+	e := g.El("div", Classes{"party-hat": true, "boring-hat": false})
+	_ = e.Render(os.Stdout)
+	// Output: <div class="party-hat"></div>
+}
+
 func hat(children ...g.Node) g.Node {
-	return Div(MergeClasses(g.Group(children), Class("hat")))
+	return Div(JoinAttrs("class", g.Group(children), Class("hat")))
 }
 
 func partyHat(children ...g.Node) g.Node {
 	return hat(ID("party-hat"), Class("party"), g.Group(children))
 }
 
-func TestMergeClasses(t *testing.T) {
+func TestJoinAttrs(t *testing.T) {
 	t.Run("merges classes", func(t *testing.T) {
-		n := partyHat(Span(ID("party-hat-text"), Class("solid"), g.Text("Yo.")))
-		assert.Equal(t, `<div id="party-hat" class="party hat"><span id="party-hat-text" class="solid">Yo.</span></div>`, n)
+		n := partyHat(Span(ID("party-hat-text"), Class("solid"), Class("gold"), g.Text("Yo.")))
+		assert.Equal(t, `<div id="party-hat" class="party hat"><span id="party-hat-text" class="solid" class="gold">Yo.</span></div>`, n)
 	})
-}
-
-func ExampleClasses() {
-	e := g.El("div", Classes{"party-hat": true, "boring-hat": false})
-	_ = e.Render(os.Stdout)
-	// Output: <div class="party-hat"></div>
 }

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -13,7 +13,10 @@ func Equal(t *testing.T, expected string, actual g.Node) {
 	t.Helper()
 
 	var b strings.Builder
-	_ = actual.Render(&b)
+	err := actual.Render(&b)
+	if err != nil {
+		t.Fatal("error rendering actual:", err)
+	}
 	if expected != b.String() {
 		t.Fatalf(`expected "%v" but got "%v"`, expected, b.String())
 	}


### PR DESCRIPTION
This adds `components.JoinAttrs`, a helper to join attribute values with a given name. Example:

```go
func myButton(children ...g.Node) g.Node {
	return Div(JoinAttrs("class", g.Group(children), Class("button")))
}

func myPrimaryButton(text string) g.Node {
	return myButton(Class("primary"), g.Text(text))
}

func ExampleJoinAttrs() {
	danceButton := myPrimaryButton("Dance")
	_ = danceButton.Render(os.Stdout)
	// Output: <div class="primary button">Dance</div>
}
```

Fixes #258 