### PR TITLE
Add Open boolean attribute for HTML details element

### DIFF
--- a/html/attributes.go
+++ b/html/attributes.go
@@ -60,6 +60,10 @@ func Muted() g.Node {
 	return g.Attr("muted")
 }
 
+func Open() g.Node {
+	return g.Attr("open")
+}
+
 func PlaysInline() g.Node {
 	return g.Attr("playsinline")
 }

--- a/html/attributes_test.go
+++ b/html/attributes_test.go
@@ -25,6 +25,7 @@ func TestBooleanAttributes(t *testing.T) {
 		{Name: "loop", Func: Loop},
 		{Name: "multiple", Func: Multiple},
 		{Name: "muted", Func: Muted},
+		{Name: "open", Func: Open},
 		{Name: "playsinline", Func: PlaysInline},
 		{Name: "readonly", Func: ReadOnly},
 		{Name: "required", Func: Required},


### PR DESCRIPTION
Fixes #268

Adds the "Open" boolean attribute helper for HTML <details> elements, as specified in https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/details#open

## Changes
- Added `Open()` function to attributes.go
- Added test case in attributes_test.go

🤖 Generated with [Claude Code](https://claude.ai/code)