### PR TITLE
Add the output HTML element

### DIFF
--- a/html/elements.go
+++ b/html/elements.go
@@ -228,6 +228,10 @@ func OptGroup(children ...g.Node) g.Node {
 	return g.El("optgroup", children...)
 }
 
+func Output(children ...g.Node) g.Node {
+	return g.El("output", children...)
+}
+
 func Option(children ...g.Node) g.Node {
 	return g.El("option", children...)
 }

--- a/html/elements_test.go
+++ b/html/elements_test.go
@@ -94,6 +94,7 @@ func TestSimpleElements(t *testing.T) {
 		{Name: "ol", Func: Ol},
 		{Name: "optgroup", Func: OptGroup},
 		{Name: "option", Func: Option},
+		{Name: "output", Func: Output},
 		{Name: "p", Func: P},
 		{Name: "picture", Func: Picture},
 		{Name: "pre", Func: Pre},


### PR DESCRIPTION
Hello! I noticed that the `<output>` element was missing from this library. This small PR addresses that.

More information about the `<output>` element can be found on [developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/output).