### PR TITLE
Optimize Text[f]

### DIFF
--- a/gomponents.go
+++ b/gomponents.go
@@ -308,26 +308,12 @@ func (a attrFunc) String() string {
 
 // Text creates a text DOM [Node] that Renders the escaped string t.
 func Text(t string) Node {
-	return NodeFunc(func(w io.Writer) error {
-		if w, ok := w.(io.StringWriter); ok {
-			_, err := w.WriteString(template.HTMLEscapeString(t))
-			return err
-		}
-		_, err := w.Write([]byte(template.HTMLEscapeString(t)))
-		return err
-	})
+	return raw(template.HTMLEscapeString(t))
 }
 
 // Textf creates a text DOM [Node] that Renders the interpolated and escaped string format.
 func Textf(format string, a ...interface{}) Node {
-	return NodeFunc(func(w io.Writer) error {
-		if w, ok := w.(io.StringWriter); ok {
-			_, err := w.WriteString(template.HTMLEscapeString(fmt.Sprintf(format, a...)))
-			return err
-		}
-		_, err := w.Write([]byte(template.HTMLEscapeString(fmt.Sprintf(format, a...))))
-		return err
-	})
+	return raw(template.HTMLEscapeString(fmt.Sprintf(format, a...)))
 }
 
 // Compile-time check that [raw] implements [fmt.Stringer] and [Node].

--- a/gomponents.go
+++ b/gomponents.go
@@ -316,10 +316,11 @@ func Textf(format string, a ...interface{}) Node {
 	return raw(template.HTMLEscapeString(fmt.Sprintf(format, a...)))
 }
 
-// Compile-time check that [raw] implements [fmt.Stringer] and [Node].
+// Compile-time check that [raw] implements [fmt.Stringer], [Node], and [nodeTypeDescriber].
 var _ interface {
 	fmt.Stringer
 	Node
+	nodeTypeDescriber
 } = raw("")
 
 // raw is a text DOM [Node] that just Renders the unescaped, underlying string.
@@ -336,6 +337,10 @@ func (r raw) Render(w io.Writer) error {
 
 func (r raw) String() string {
 	return string(r)
+}
+
+func (r raw) Type() NodeType {
+	return ElementType
 }
 
 // Raw creates a text DOM [Node] that just Renders the unescaped string t.

--- a/gomponents_benchmark_test.go
+++ b/gomponents_benchmark_test.go
@@ -66,3 +66,27 @@ func BenchmarkRawf(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkText(b *testing.B) {
+	b.Run("simple text element", func(b *testing.B) {
+		var sb strings.Builder
+
+		for b.Loop() {
+			e := g.Text("some simple text")
+			_ = e.Render(&sb)
+			sb.Reset()
+		}
+	})
+}
+
+func BenchmarkTextf(b *testing.B) {
+	b.Run("formatted text element", func(b *testing.B) {
+		var sb strings.Builder
+
+		for b.Loop() {
+			e := g.Textf("some %s text", "formatted")
+			_ = e.Render(&sb)
+			sb.Reset()
+		}
+	})
+}


### PR DESCRIPTION
By making use of the new `raw` type, we can also simplify and optimize `Text[f]`, similar to the `Raw[f]` optimizations[0].

Before:
    
```
❯ go test . -bench=Text -benchmem
goos: linux
goarch: amd64
pkg: maragu.dev/gomponents
cpu: AMD Ryzen 9 9950X3D 16-Core Processor
BenchmarkText/simple_text_element-32            32014112               41.18 ns/op           40 B/op          2 allocs/op
BenchmarkTextf/formatted_text_element-32        13197096               92.03 ns/op          112 B/op          4 allocs/op
PASS
ok      maragu.dev/gomponents   2.536s
```

After:

```
❯ go test . -bench=Text -benchmem
goos: linux
goarch: amd64
pkg: maragu.dev/gomponents
cpu: AMD Ryzen 9 9950X3D 16-Core Processor
BenchmarkText/simple_text_element-32            32165613               39.41 ns/op           32 B/op          2 allocs/op
BenchmarkTextf/formatted_text_element-32        15473426               77.65 ns/op           64 B/op          3 allocs/op
PASS
ok      maragu.dev/gomponents   2.472s
```

[0]: https://github.com/maragudk/gomponents/pull/307