### PR TITLE
Add implementation for sizes attribute

### DIFF
--- a/html/attributes.go
+++ b/html/attributes.go
@@ -144,7 +144,7 @@ func DataAttr(name, v string) g.Node {
 }
 
 func SlotAttr(v string) g.Node {
-  return g.Attr("slot", v)
+	return g.Attr("slot", v)
 }
 
 func For(v string) g.Node {
@@ -281,6 +281,10 @@ func Rows(v string) g.Node {
 
 func RowSpan(v string) g.Node {
 	return g.Attr("rowspan", v)
+}
+
+func Sizes(v string) g.Node {
+	return g.Attr("sizes", v)
 }
 
 func Scope(v string) g.Node {

--- a/html/attributes_test.go
+++ b/html/attributes_test.go
@@ -94,6 +94,7 @@ func TestSimpleAttributes(t *testing.T) {
 		{Name: "role", Func: Role},
 		{Name: "rows", Func: Rows},
 		{Name: "rowspan", Func: RowSpan},
+		{Name: "sizes", Func: Sizes},
 		{Name: "scope", Func: Scope},
 		{Name: "spellcheck", Func: SpellCheck},
 		{Name: "slot", Func: SlotAttr},
@@ -128,17 +129,17 @@ func TestVariadicAttributes(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.Name + "(no args)", func(t *testing.T) {
+		t.Run(test.Name+"(no args)", func(t *testing.T) {
 			n := g.El("div", test.Func())
 			assert.Equal(t, fmt.Sprintf(`<div %v></div>`, test.Name), n)
 		})
 
-		t.Run(test.Name +"(one arg)", func(t *testing.T) {
+		t.Run(test.Name+"(one arg)", func(t *testing.T) {
 			n := g.El("div", test.Func("hat"))
 			assert.Equal(t, fmt.Sprintf(`<div %v="hat"></div>`, test.Name), n)
 		})
 
-		t.Run(test.Name + "(two args panics)", func(t *testing.T) {
+		t.Run(test.Name+"(two args panics)", func(t *testing.T) {
 			defer func() {
 				if r := recover(); r == nil {
 					t.Errorf("expected a panic")


### PR DESCRIPTION
The goal of this MR is to solve issue with missing a dedicated function for defining `sizes` attribute on a node. For more details see the folowing issue: https://github.com/maragudk/gomponents/issues/315