### PR TITLE
Add missing track element

### DIFF
--- a/html/elements.go
+++ b/html/elements.go
@@ -469,3 +469,7 @@ func Var(children ...g.Node) g.Node {
 func Video(children ...g.Node) g.Node {
 	return g.El("video", g.Group(children))
 }
+
+func Track(children ...g.Node) g.Node {
+	return g.El("track", children...)
+}

--- a/html/elements_test.go
+++ b/html/elements_test.go
@@ -157,6 +157,7 @@ func TestSimpleVoidKindElements(t *testing.T) {
 		{Name: "param", Func: Param},
 		{Name: "source", Func: Source},
 		{Name: "wbr", Func: Wbr},
+		{Name: "track", Func: Track},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
I noticed that the [`track` element](https://www.w3.org/TR/2011/WD-html-markup-20110113/track.html) is missing. It is already listed in `isVoidElement`, but not actually implemented itself.