### PR TITLE
Fix `JoinAttrs` not joining attributes in nested groups

### DIFF
--- a/components/components.go
+++ b/components/components.go
@@ -67,14 +67,17 @@ func (c Classes) String() string {
 }
 
 // JoinAttrs joins attributes with the given name on the first level of the given nodes.
-// Attributes on non-direct descendants are ignored.
+// A [g.Group] is transparent and doesn't count as a level, so attributes inside one are joined
+// at any depth, matching how groups are rendered.
+// Attributes on non-direct descendants, for example inside a child element, are ignored.
 // Non-empty attribute values are joined by spaces into a single attribute.
 // Empty, whitespace-only, and boolean (valueless) attributes are deduplicated and discarded
 // if a non-empty value exists. If only boolean/empty attributes match, a single boolean
 // attribute is emitted.
 // When both boolean and valued attributes match, the valued form takes precedence.
 // The name is rendered unescaped and must be a trusted value, never user-controlled data.
-// Note that this renders all first-level attributes to check whether they should be processed.
+// Note that this renders all first-level attributes, at any group depth, to check whether they
+// should be processed.
 func JoinAttrs(name string, children ...g.Node) g.Node {
 	var attrValues []string
 	var result []g.Node
@@ -82,7 +85,16 @@ func JoinAttrs(name string, children ...g.Node) g.Node {
 	sawBoolAttr := false
 
 	// processNode checks a single child node and either collects its value or appends it to result.
-	processNode := func(n g.Node) {
+	// Groups are unwrapped recursively, mirroring how they are rendered.
+	var processNode func(n g.Node)
+	processNode = func(n g.Node) {
+		if group, ok := n.(g.Group); ok {
+			for _, groupChild := range group {
+				processNode(groupChild)
+			}
+			return
+		}
+
 		isGivenAttr, attrValue := extractAttrValue(name, n)
 		if !isGivenAttr {
 			result = append(result, n)
@@ -104,12 +116,6 @@ func JoinAttrs(name string, children ...g.Node) g.Node {
 	}
 
 	for _, child := range children {
-		if group, ok := child.(g.Group); ok {
-			for _, groupChild := range group {
-				processNode(groupChild)
-			}
-			continue
-		}
 		processNode(child)
 	}
 

--- a/components/components_test.go
+++ b/components/components_test.go
@@ -176,5 +176,25 @@ func TestJoinAttrs(t *testing.T) {
 		n := Div(JoinAttrs("data-test", g.Attr("data-test", `<script>"test"</script>`), g.Attr("data-test", "more")))
 		assert.Equal(t, `<div data-test="&lt;script&gt;&#34;test&#34;&lt;/script&gt; more"></div>`, n)
 	})
+
+	t.Run("joins classes in nested groups", func(t *testing.T) {
+		n := Div(JoinAttrs("class", g.Group{Class("party"), g.Group{Class("gold")}}, Class("hat")))
+		assert.Equal(t, `<div class="party gold hat"></div>`, n)
+	})
+
+	t.Run("joins classes in deeply nested groups", func(t *testing.T) {
+		n := Div(JoinAttrs("class", g.Group{g.Group{g.Group{Class("a")}, Class("b")}, Class("c")}, Class("d")))
+		assert.Equal(t, `<div class="a b c d"></div>`, n)
+	})
+
+	t.Run("joins classes passed through nested components", func(t *testing.T) {
+		n := partyHat(Class("gold"), g.Text("Yo."))
+		assert.Equal(t, `<div id="party-hat" class="party gold hat">Yo.</div>`, n)
+	})
+
+	t.Run("keeps element order when joining classes in nested groups", func(t *testing.T) {
+		n := Div(JoinAttrs("class", g.Group{g.Text("a"), g.Group{Class("x"), g.Text("b")}, Class("y")}))
+		assert.Equal(t, `<div class="x y">ab</div>`, n)
+	})
 }
 


### PR DESCRIPTION
`JoinAttrs` unwraps `g.Group` only one level deep, so an attribute nested deeper is never
merged. It falls through to the result verbatim, and `renderChild`, which recurses into groups
at any depth, then emits it as a second attribute of the same name. Browsers keep the first
occurrence, so the value is silently dropped.

### Reproduction

Against `main` @ d1fd82b:

```go
Div(JoinAttrs("class", g.Group{Class("party"), g.Group{Class("gold")}}, Class("hat")))
```

renders

```html
<div class="party hat" class="gold"></div>
```

instead of `<div class="party gold hat"></div>`. With three levels it degrades further —
`<div class="a" class="b" class="c d"></div>`.

### Why it comes up

Two-level groups arise from the composition pattern the docs already show: a component that
forwards `g.Group(children)` into `JoinAttrs`, called by another component that does the same.
`g.Map` also returns a `Group`, so mapping over data into a `JoinAttrs` call hits it too. The
existing group test missed this because it forwards an element rather than an attribute, and
elements are appended to `result` either way.

### Fix

Unwrap recursively in `processNode`, mirroring what `renderChild` does, so `JoinAttrs` sees
exactly what will be rendered. Element order is preserved: non-attribute children stay in place
and the joined attribute lands at the position of the first match, same as before.

Four test cases added — two-level, three-level, nested components, and element order inside
nested groups. Existing tests unchanged, coverage stays at 100%.

The doc comment is updated to say groups are transparent, since the previous wording
("Attributes on non-direct descendants are ignored") no longer describes the behaviour.
