### PR TITLE
Benchmark against writers that don't allocate per render

### DIFF
--- a/gomponents_benchmark_test.go
+++ b/gomponents_benchmark_test.go
@@ -3,7 +3,7 @@
 package gomponents_test
 
 import (
-	"strings"
+	"io"
 	"testing"
 
 	g "maragu.dev/gomponents"
@@ -11,82 +11,61 @@ import (
 
 func BenchmarkAttr(b *testing.B) {
 	b.Run("boolean attributes", func(b *testing.B) {
-		var sb strings.Builder
-
 		for b.Loop() {
 			a := g.Attr("hat")
-			_ = a.Render(&sb)
-			sb.Reset()
+			_ = a.Render(io.Discard)
 		}
 	})
 
 	b.Run("name-value attributes", func(b *testing.B) {
-		var sb strings.Builder
-
 		for b.Loop() {
 			a := g.Attr("hat", "party")
-			_ = a.Render(&sb)
-			sb.Reset()
+			_ = a.Render(io.Discard)
 		}
 	})
 }
 
 func BenchmarkEl(b *testing.B) {
 	b.Run("normal elements", func(b *testing.B) {
-		var sb strings.Builder
-
 		for b.Loop() {
 			e := g.El("div")
-			_ = e.Render(&sb)
-			sb.Reset()
+			_ = e.Render(io.Discard)
 		}
 	})
 }
 
 func BenchmarkRaw(b *testing.B) {
 	b.Run("raw element", func(b *testing.B) {
-		var sb strings.Builder
-
 		for b.Loop() {
 			e := g.Raw("<span>content</span>")
-			_ = e.Render(&sb)
-			sb.Reset()
+			_ = e.Render(io.Discard)
 		}
 	})
 }
 
 func BenchmarkRawf(b *testing.B) {
 	b.Run("formatted raw element", func(b *testing.B) {
-		var sb strings.Builder
-
 		for b.Loop() {
 			e := g.Rawf("<span>%s</span>", "content")
-			_ = e.Render(&sb)
-			sb.Reset()
+			_ = e.Render(io.Discard)
 		}
 	})
 }
 
 func BenchmarkText(b *testing.B) {
 	b.Run("simple text element", func(b *testing.B) {
-		var sb strings.Builder
-
 		for b.Loop() {
 			e := g.Text("some simple text")
-			_ = e.Render(&sb)
-			sb.Reset()
+			_ = e.Render(io.Discard)
 		}
 	})
 }
 
 func BenchmarkTextf(b *testing.B) {
 	b.Run("formatted text element", func(b *testing.B) {
-		var sb strings.Builder
-
 		for b.Loop() {
 			e := g.Textf("some %s text", "formatted")
-			_ = e.Render(&sb)
-			sb.Reset()
+			_ = e.Render(io.Discard)
 		}
 	})
 }

--- a/html/benchmark_test.go
+++ b/html/benchmark_test.go
@@ -3,14 +3,19 @@
 package html_test
 
 import (
+	"bufio"
 	"fmt"
-	"strings"
+	"io"
 	"testing"
 
 	g "maragu.dev/gomponents"
 	c "maragu.dev/gomponents/components"
 	. "maragu.dev/gomponents/html"
 )
+
+// responseBufferSize is the size of the [bufio.Writer] that net/http puts in front of a
+// handler's [http.ResponseWriter], its bufferBeforeChunkingSize.
+const responseBufferSize = 2048
 
 // BenchmarkRealisticPage benchmarks rendering a full, realistic HTML page
 // resembling a typical web application dashboard with navigation, sidebar,
@@ -275,19 +280,36 @@ func BenchmarkRealisticPage(b *testing.B) {
 	}
 
 	b.Run("construct and render", func(b *testing.B) {
-		var sb strings.Builder
-		for b.Loop() {
-			_ = page().Render(&sb)
-			sb.Reset()
-		}
+		b.Run("discarded", func(b *testing.B) {
+			for b.Loop() {
+				_ = page().Render(io.Discard)
+			}
+		})
+
+		b.Run("buffered", func(b *testing.B) {
+			w := bufio.NewWriterSize(io.Discard, responseBufferSize)
+			for b.Loop() {
+				_ = page().Render(w)
+				_ = w.Flush()
+			}
+		})
 	})
 
 	b.Run("render pre-built tree", func(b *testing.B) {
-		var sb strings.Builder
 		p := page()
-		for b.Loop() {
-			_ = p.Render(&sb)
-			sb.Reset()
-		}
+
+		b.Run("discarded", func(b *testing.B) {
+			for b.Loop() {
+				_ = p.Render(io.Discard)
+			}
+		})
+
+		b.Run("buffered", func(b *testing.B) {
+			w := bufio.NewWriterSize(io.Discard, responseBufferSize)
+			for b.Loop() {
+				_ = p.Render(w)
+				_ = w.Flush()
+			}
+		})
 	})
 }


### PR DESCRIPTION
The benchmarks render into a `strings.Builder` and call `Reset` between iterations. `strings.Builder.Reset` drops the underlying buffer rather than keeping it, so every iteration re-grows it from nil, and the reported numbers include the allocator work of the benchmark harness itself rather than just the library's.

`bytes.Buffer.Reset` keeps its capacity, which isolates the code under test. It's also closer to real usage, where output goes to a writer that isn't re-allocated per render.

`BenchmarkRealisticPage`, `-count=5`, go1.24.10, linux/amd64:

| | B/op | ns/op |
|---|---|---|
| construct and render | 342216 → 130325 (-62%) | 182366 → 145494 (-20%) |
| render pre-built tree | 213556 → 1863 (-99%) | 114446 → 66015 (-42%) |

The micro benchmarks are affected the same way — `BenchmarkAttr/name-value` and `BenchmarkEl/normal_elements` drop from 3 allocs/op to 1, and `BenchmarkAttr/boolean` and `BenchmarkText/simple` from 2 to 1. The library only ever made one; the rest was the builder re-growing.

For the pre-built tree case that means 99% of the memory being measured was the harness, not the render.

Worth noting that this makes the numbers incomparable to any recorded before it, so it's a one-off break in the series. Test-only change, no library code touched.

---

**Update:** after review by @Hendrikto and @markuswustenberg, the approach changed. The per-attribute and per-element benchmarks now render to `io.Discard`, and `BenchmarkRealisticPage` keeps its construct/pre-built split while gaining a `discarded`/`buffered` writer axis, where `buffered` is a `bufio.Writer` of 2048 bytes — the size `net/http` puts in front of a handler's `ResponseWriter`. Numbers and reasoning in [this comment](https://github.com/maragudk/gomponents/pull/346#issuecomment-5526172524). Everything above is the original proposal, kept as it was so the discussion still reads.
