### PR TITLE
Reduce allocations in JoinAttrs

### DIFF
--- a/components/benchmark_test.go
+++ b/components/benchmark_test.go
@@ -1,0 +1,69 @@
+//go:build go1.24
+
+package components_test
+
+import (
+	"io"
+	"testing"
+
+	g "maragu.dev/gomponents"
+	. "maragu.dev/gomponents/components"
+	. "maragu.dev/gomponents/html"
+)
+
+func BenchmarkJoinAttrs(b *testing.B) {
+	flat := func() []g.Node {
+		return []g.Node{
+			Class("inline-flex items-center"),
+			ID("badge"),
+			Class("px-2.5 py-0.5 rounded-full"),
+			Type("button"),
+			Class("bg-green-100 text-green-800"),
+		}
+	}
+
+	nested := func() []g.Node {
+		return []g.Node{
+			Class("inline-flex items-center"),
+			g.Group{
+				ID("badge"),
+				g.Group{
+					Class("px-2.5 py-0.5 rounded-full"),
+					Class("bg-green-100 text-green-800"),
+				},
+			},
+			Type("button"),
+		}
+	}
+
+	noMatch := func() []g.Node {
+		return []g.Node{ID("badge"), Type("button"), Lang("en"), Title("hat")}
+	}
+
+	cases := []struct {
+		Name     string
+		Children func() []g.Node
+	}{
+		{Name: "flat", Children: flat},
+		{Name: "nested groups", Children: nested},
+		{Name: "no match", Children: noMatch},
+	}
+
+	for _, c := range cases {
+		b.Run(c.Name+"/construct", func(b *testing.B) {
+			children := c.Children()
+
+			for b.Loop() {
+				_ = JoinAttrs("class", children...)
+			}
+		})
+
+		b.Run(c.Name+"/construct and render", func(b *testing.B) {
+			children := c.Children()
+
+			for b.Loop() {
+				_ = JoinAttrs("class", children...).Render(io.Discard)
+			}
+		})
+	}
+}

--- a/components/components.go
+++ b/components/components.go
@@ -2,6 +2,7 @@
 package components
 
 import (
+	"bytes"
 	"html"
 	"io"
 	"sort"
@@ -81,8 +82,12 @@ func (c Classes) String() string {
 func JoinAttrs(name string, children ...g.Node) g.Node {
 	// The two shapes an attribute called name renders as. extractAttrValue compares against
 	// them for every child, so build them once instead of per child.
-	boolAttr := " " + name
-	attrPrefix := boolAttr + `="`
+	boolAttr := []byte(" " + name)
+	attrPrefix := []byte(" " + name + `="`)
+
+	// One buffer for every child. bytes.Buffer.Reset keeps its capacity, so inspecting the
+	// second child doesn't re-grow it from nil the way a fresh strings.Builder would.
+	var buf bytes.Buffer
 
 	var attrValues []string
 	result := make([]g.Node, 0, len(children))
@@ -100,7 +105,7 @@ func JoinAttrs(name string, children ...g.Node) g.Node {
 			return
 		}
 
-		isGivenAttr, attrValue := extractAttrValue(boolAttr, attrPrefix, n)
+		isGivenAttr, attrValue := extractAttrValue(&buf, boolAttr, attrPrefix, n)
 		if !isGivenAttr {
 			result = append(result, n)
 			return
@@ -143,36 +148,43 @@ func JoinAttrs(name string, children ...g.Node) g.Node {
 	return g.Group(result)
 }
 
+var quote = []byte(`"`)
+
 type nodeTypeDescriber interface {
 	Type() g.NodeType
 }
 
-func extractAttrValue(boolAttr, attrPrefix string, n g.Node) (bool, string) {
+func extractAttrValue(buf *bytes.Buffer, boolAttr, attrPrefix []byte, n g.Node) (bool, string) {
 	// Ignore everything that is not an attribute
 	if n, ok := n.(nodeTypeDescriber); !ok || n.Type() == g.ElementType {
 		return false, ""
 	}
 
-	var b strings.Builder
-	if err := n.Render(&b); err != nil {
+	buf.Reset()
+	if err := n.Render(buf); err != nil {
 		return false, ""
 	}
 
-	rendered := b.String()
+	// Only valid until the next Reset, so it must not outlive this call.
+	rendered := buf.Bytes()
 
 	// Match boolean attribute (e.g., ` required`)
-	if rendered == boolAttr {
+	if bytes.Equal(rendered, boolAttr) {
 		return true, ""
 	}
 
-	if !strings.HasPrefix(rendered, attrPrefix) || !strings.HasSuffix(rendered, `"`) {
+	if !bytes.HasPrefix(rendered, attrPrefix) || !bytes.HasSuffix(rendered, quote) {
 		return false, ""
 	}
 
-	v := strings.TrimPrefix(rendered, attrPrefix)
-	v = strings.TrimSuffix(v, `"`)
+	// A node that rendered as just ` name="` has the prefix's own quote as its suffix and
+	// nothing in between, so there is no value to take.
+	if len(rendered) == len(attrPrefix) {
+		return true, ""
+	}
+
 	// Unescape to get the original value, since it will be escaped again when the joined attribute is rendered
-	v = html.UnescapeString(v)
+	v := html.UnescapeString(string(rendered[len(attrPrefix) : len(rendered)-1]))
 	// Treat whitespace-only values the same as empty
 	if strings.TrimSpace(v) == "" {
 		return true, ""

--- a/components/components.go
+++ b/components/components.go
@@ -79,8 +79,13 @@ func (c Classes) String() string {
 // Note that this renders all first-level attributes, at any group depth, to check whether they
 // should be processed.
 func JoinAttrs(name string, children ...g.Node) g.Node {
+	// The two shapes an attribute called name renders as. extractAttrValue compares against
+	// them for every child, so build them once instead of per child.
+	boolAttr := " " + name
+	attrPrefix := boolAttr + `="`
+
 	var attrValues []string
-	var result []g.Node
+	result := make([]g.Node, 0, len(children))
 	firstAttrIndex := -1
 	sawBoolAttr := false
 
@@ -95,7 +100,7 @@ func JoinAttrs(name string, children ...g.Node) g.Node {
 			return
 		}
 
-		isGivenAttr, attrValue := extractAttrValue(name, n)
+		isGivenAttr, attrValue := extractAttrValue(boolAttr, attrPrefix, n)
 		if !isGivenAttr {
 			result = append(result, n)
 			return
@@ -107,6 +112,11 @@ func JoinAttrs(name string, children ...g.Node) g.Node {
 				result = append(result, nil)
 			}
 			return
+		}
+		if attrValues == nil {
+			// Only reached when there is something to join, so don't allocate for the
+			// common case of a child list with no matching attribute at all.
+			attrValues = make([]string, 0, len(children))
 		}
 		attrValues = append(attrValues, attrValue)
 		if firstAttrIndex == -1 {
@@ -137,7 +147,7 @@ type nodeTypeDescriber interface {
 	Type() g.NodeType
 }
 
-func extractAttrValue(name string, n g.Node) (bool, string) {
+func extractAttrValue(boolAttr, attrPrefix string, n g.Node) (bool, string) {
 	// Ignore everything that is not an attribute
 	if n, ok := n.(nodeTypeDescriber); !ok || n.Type() == g.ElementType {
 		return false, ""
@@ -151,15 +161,15 @@ func extractAttrValue(name string, n g.Node) (bool, string) {
 	rendered := b.String()
 
 	// Match boolean attribute (e.g., ` required`)
-	if rendered == " "+name {
+	if rendered == boolAttr {
 		return true, ""
 	}
 
-	if !strings.HasPrefix(rendered, " "+name+`="`) || !strings.HasSuffix(rendered, `"`) {
+	if !strings.HasPrefix(rendered, attrPrefix) || !strings.HasSuffix(rendered, `"`) {
 		return false, ""
 	}
 
-	v := strings.TrimPrefix(rendered, " "+name+`="`)
+	v := strings.TrimPrefix(rendered, attrPrefix)
 	v = strings.TrimSuffix(v, `"`)
 	// Unescape to get the original value, since it will be escaped again when the joined attribute is rendered
 	v = html.UnescapeString(v)

--- a/components/components_test.go
+++ b/components/components_test.go
@@ -111,6 +111,17 @@ func (b *brokenNode) Type() g.NodeType {
 	return g.AttributeType
 }
 
+// truncatedAttrNode renders as an attribute whose value is cut off after the opening quote,
+// which is the one shape where the rendered text ends with the same quote it starts the value with.
+type truncatedAttrNode struct{ name string }
+
+func (t truncatedAttrNode) Render(w io.Writer) error {
+	_, err := io.WriteString(w, " "+t.name+`="`)
+	return err
+}
+
+func (truncatedAttrNode) Type() g.NodeType { return g.AttributeType }
+
 // recorder is a [g.Node] that records whether Render was called on it.
 type recorder struct{ rendered bool }
 
@@ -142,6 +153,16 @@ func TestJoinAttrs(t *testing.T) {
 	t.Run("does nothing if attribute not found", func(t *testing.T) {
 		n := Div(JoinAttrs("style", Class("party"), ID("hey"), Class("hat")))
 		assert.Equal(t, `<div class="party" id="hey" class="hat"></div>`, n)
+	})
+
+	t.Run("treats an attribute truncated after the opening quote as having no value", func(t *testing.T) {
+		n := Div(JoinAttrs("class", truncatedAttrNode{name: "class"}))
+		assert.Equal(t, `<div class></div>`, n)
+	})
+
+	t.Run("lets a real value win over a truncated one", func(t *testing.T) {
+		n := Div(JoinAttrs("class", truncatedAttrNode{name: "class"}, Class("hat")))
+		assert.Equal(t, `<div class="hat"></div>`, n)
 	})
 
 	t.Run("ignores nodes that can't render", func(t *testing.T) {


### PR DESCRIPTION
Rebased onto #346, now that it's on main. The benchmark added here renders to `io.Discard`, following the convention settled there — without it, it would measure its own output buffer re-growing more than it measures `JoinAttrs`.

Three commits, each standing on its own:

**1. Add a `JoinAttrs` benchmark.** There wasn't one. It covers a flat child list, the nested groups #335 taught it to flatten, and a list with nothing to join. Construct is split from construct-and-render, because `JoinAttrs` does all of its work when it's called — render turns out to add ~10ns and no allocations at all.

**2. Hoist the prefixes and give the slices their capacity.** `extractAttrValue` rebuilt `" "+name` and `" "+name+`="`` for every child it inspected, though `name` is fixed for the whole call. It was the largest CPU entry after the render itself, showing up as `runtime.concatstrings`. `attrValues` stays lazily allocated so a child list with no matching attribute doesn't pay for it.

**3. Reuse one buffer.** Every child got its own `strings.Builder`, re-grown from nil each time — about 78% of all remaining allocations. One `bytes.Buffer` in `JoinAttrs` instead, whose `Reset` keeps its capacity, matching on bytes so the per-child string goes away too.

Cumulative, `BenchmarkJoinAttrs`, `-count=10`, go1.24.10, linux/amd64:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| flat | -47% | -36% | 25 → 10 |
| nested groups | -47% | -44% | 25 → 10 |
| no match | -49% | -44% | 16 → 4 |

Rendered output is unchanged throughout.

Commit 3 turned up an edge case worth pinning down. A node that renders as just `` name="`` ends with the same quote the prefix opens the value with, so slicing the value out naively runs off the end. It has always been treated as an attribute with no value, and still is — there are now tests for it and for the case where a real value follows it. Those tests pass against the code as it is on main too, so they document existing behaviour rather than new behaviour.

One thing I deliberately left alone: `extractAttrValue` renders each attribute, which escapes the value, then unescapes it, and the joined attribute escapes it again on render. `template.HTMLEscapeString` is about 13% of CPU purely because of that round trip. Avoiding it means getting at an attribute's value without rendering it, which needs something new in the root package — a bigger design question than this PR, and your call rather than mine.
