### PR TITLE
Drop the html/template dependency

### DIFF
--- a/gomponents.go
+++ b/gomponents.go
@@ -23,7 +23,6 @@ package gomponents
 
 import (
 	"fmt"
-	"html/template"
 	"io"
 	"strings"
 )
@@ -219,18 +218,28 @@ func booleanAttr(name string) Node {
 	})
 }
 
-// htmlEscapeSet holds the characters that [template.HTMLEscapeString] escapes.
-// It checks for them with [strings.ContainsAny], which rebuilds an ASCII bitmap from its
-// constant cutset on every call; this table is built once instead.
+// htmlEscapeSet holds the characters that need escaping, and htmlEscaper is what escapes
+// them. Both are the six replacements [text/template.HTMLEscape] makes, and escapeString
+// is required by test to agree with [text/template.HTMLEscapeString] on every input.
 var htmlEscapeSet = [256]bool{0: true, '\'': true, '"': true, '&': true, '<': true, '>': true}
 
-// escapeString is [template.HTMLEscapeString], but it decides whether there is anything to
-// escape without rebuilding that bitmap. Strings with nothing to escape, which is nearly all
-// of them, are returned untouched, exactly as [template.HTMLEscapeString] returns them.
+var htmlEscaper = strings.NewReplacer(
+	"\x00", "\uFFFD",
+	`"`, "&#34;",
+	"'", "&#39;",
+	"&", "&amp;",
+	"<", "&lt;",
+	">", "&gt;",
+)
+
+// escapeString escapes the characters that HTML gives meaning to, deciding whether there is
+// anything to escape with a table built once rather than with [strings.ContainsAny], which
+// rebuilds an ASCII bitmap from its constant cutset on every call. Strings with nothing to
+// escape, which is nearly all of them, are returned untouched.
 func escapeString(s string) string {
 	for i := 0; i < len(s); i++ {
 		if htmlEscapeSet[s[i]] {
-			return template.HTMLEscapeString(s)
+			return htmlEscaper.Replace(s)
 		}
 	}
 	return s

--- a/gomponents_benchmark_test.go
+++ b/gomponents_benchmark_test.go
@@ -10,10 +10,6 @@ import (
 	g "maragu.dev/gomponents"
 )
 
-// escapedProse is the kind of user-written text that takes the escaping path. English prose
-// contains apostrophes, which is enough on its own.
-var escapedProse = strings.Repeat("It's a paragraph of user-written text, with quotes & apostrophes in it. ", 40)
-
 func BenchmarkAttr(b *testing.B) {
 	b.Run("boolean attributes", func(b *testing.B) {
 		for b.Loop() {
@@ -80,8 +76,12 @@ func BenchmarkText(b *testing.B) {
 	})
 
 	b.Run("prose element needing escaping", func(b *testing.B) {
+		// English prose contains apostrophes, which on its own is enough to take the
+		// escaping path.
+		prose := strings.Repeat("It's a paragraph of user-written text, with quotes & apostrophes in it. ", 40)
+
 		for b.Loop() {
-			e := g.Text(escapedProse)
+			e := g.Text(prose)
 			_ = e.Render(io.Discard)
 		}
 	})

--- a/gomponents_benchmark_test.go
+++ b/gomponents_benchmark_test.go
@@ -4,10 +4,15 @@ package gomponents_test
 
 import (
 	"io"
+	"strings"
 	"testing"
 
 	g "maragu.dev/gomponents"
 )
+
+// escapedProse is the kind of user-written text that takes the escaping path. English prose
+// contains apostrophes, which is enough on its own.
+var escapedProse = strings.Repeat("It's a paragraph of user-written text, with quotes & apostrophes in it. ", 40)
 
 func BenchmarkAttr(b *testing.B) {
 	b.Run("boolean attributes", func(b *testing.B) {
@@ -20,6 +25,13 @@ func BenchmarkAttr(b *testing.B) {
 	b.Run("name-value attributes", func(b *testing.B) {
 		for b.Loop() {
 			a := g.Attr("hat", "party")
+			_ = a.Render(io.Discard)
+		}
+	})
+
+	b.Run("name-value attributes needing escaping", func(b *testing.B) {
+		for b.Loop() {
+			a := g.Attr("hat", `"party" & fun`)
 			_ = a.Render(io.Discard)
 		}
 	})
@@ -56,6 +68,20 @@ func BenchmarkText(b *testing.B) {
 	b.Run("simple text element", func(b *testing.B) {
 		for b.Loop() {
 			e := g.Text("some simple text")
+			_ = e.Render(io.Discard)
+		}
+	})
+
+	b.Run("text element needing escaping", func(b *testing.B) {
+		for b.Loop() {
+			e := g.Text("It's a sentence & it needs escaping.")
+			_ = e.Render(io.Discard)
+		}
+	})
+
+	b.Run("prose element needing escaping", func(b *testing.B) {
+		for b.Loop() {
+			e := g.Text(escapedProse)
 			_ = e.Render(io.Discard)
 		}
 	})

--- a/gomponents_internal_test.go
+++ b/gomponents_internal_test.go
@@ -15,8 +15,9 @@ func TestRaw(t *testing.T) {
 }
 
 func TestEscapeString(t *testing.T) {
-	// escapeString must agree with template.HTMLEscapeString on every input, because it
-	// decides whether escaping happens at all. A false negative would pass markup through.
+	// escapeString must agree with template.HTMLEscapeString on every input. It no longer
+	// calls it — it decides whether to escape and then escapes on its own — so this is what
+	// holds the two together. A false negative would pass markup through.
 	same := func(t *testing.T, s string) {
 		t.Helper()
 		if got, want := escapeString(s), template.HTMLEscapeString(s); got != want {
@@ -41,6 +42,12 @@ func TestEscapeString(t *testing.T) {
 	t.Run("longer than the eight bytes that switch strings.IndexAny strategy", func(t *testing.T) {
 		for i := 0; i < 256; i++ {
 			same(t, "0123456789"+string([]byte{byte(i)})+"0123456789")
+		}
+	})
+
+	t.Run("each escaped character on its own", func(t *testing.T) {
+		for _, s := range []string{"\x00", `"`, "'", "&", "<", ">"} {
+			same(t, s)
 		}
 	})
 

--- a/gomponents_internal_test.go
+++ b/gomponents_internal_test.go
@@ -2,6 +2,7 @@ package gomponents
 
 import (
 	"html/template"
+	"strings"
 	"testing"
 )
 
@@ -43,6 +44,26 @@ func TestEscapeString(t *testing.T) {
 		for i := 0; i < 256; i++ {
 			same(t, "0123456789"+string([]byte{byte(i)})+"0123456789")
 		}
+	})
+
+	t.Run("either side of the forty-eight bytes that switch strings.Replacer strategy", func(t *testing.T) {
+		// Below len(toReplace)*countCutOff, which is 48 for six characters,
+		// byteStringReplacer sizes its output by walking the string once; from there on it
+		// counts each of the six separately. Both paths have to agree with the reference.
+		for _, n := range []int{47, 48, 49} {
+			for _, c := range []string{"\x00", `"`, "'", "&", "<", ">"} {
+				same(t, c+strings.Repeat("a", n-1))
+				same(t, strings.Repeat("a", n-1)+c)
+				same(t, strings.Repeat("a", n/2)+c+strings.Repeat("a", n-n/2-1))
+			}
+		}
+	})
+
+	t.Run("long strings on the counting path", func(t *testing.T) {
+		same(t, "&"+strings.Repeat("a", 4095))
+		same(t, strings.Repeat("a", 4095)+"&")
+		same(t, strings.Repeat(`a"b'c&d<e>f`, 400))
+		same(t, strings.Repeat("\x00", 4096))
 	})
 
 	t.Run("each escaped character on its own", func(t *testing.T) {


### PR DESCRIPTION
Following up on my last comment on #348, where I said I'd open this separately.

After the escape fast path landed, `template.HTMLEscapeString` was the only thing left in the library reaching into `html/template` — one six-character escaper in exchange for the heaviest dependency in the module. This replaces it with a `strings.NewReplacer` holding exactly the six replacements `text/template.HTMLEscape` makes.

**Output is unchanged, byte for byte.**

Seventeen packages leave the root package's dependency set — `text/template`, `text/template/parse`, `regexp`, `regexp/syntax`, `encoding/json`, `encoding/base64`, `encoding/binary`, `encoding`, `net/url`, `net/netip`, `path/filepath`, `unicode/utf16`, `unique`, `weak`, `maps`, `bytes` and `html/template` itself. `go list -deps .` goes from **76 to 57**.

| | main | this PR | |
|---|---|---|---|
| minimal program | 2 787 119 B | 1 956 627 B | -811 KiB |
| `net/http` + `encoding/json` + `regexp` | 8 920 166 B | 8 837 036 B | **-81 KiB (-0.93%)** |

The second row is the honest headline. Most of those packages come back the moment an application imports `net/http` or `regexp` on its own; what's left is `text/template` and friends, which nothing else pulls in. So it's -0.9% of a real binary, not -30%.

**On trusting it.** The tests still import `html/template` and still compare against `HTMLEscapeString` — every byte, all 65536 pairs of bytes, strings either side of the length-8 boundary, the named cases, and the fuzz target (62 million executions, no divergence). Test imports don't count towards the library's dependencies, so the equivalence stays proven while the package stops shipping. If you'd rather keep delegating to the standard library, that's a fair call and this is easy to close — but I don't think the proof gets weaker by moving the escaper in-tree, given it's six replacements checked against the reference on every input.

**Performance is unchanged**, as it has to be: the replacer only runs for strings that actually contain one of the six characters, which in `BenchmarkRealisticPage` is one string out of 235. Two independent `-count=10` rounds on the same two binaries give geomean `+1.4%` and `-1.9%` — the sign flips, so that's layout and machine noise rather than the change.

@Hendrikto spotted this in #348. He proposed `html.EscapeString`, which differs from `text/template` on exactly one input (NUL); a local replacer needs no decision about that, because nothing about the behaviour changes.
